### PR TITLE
infra: port Kimi K2.6 text provider swap from K2B

### DIFF
--- a/scripts/lib/minimax_common.py
+++ b/scripts/lib/minimax_common.py
@@ -4,9 +4,13 @@ Always uses the global endpoint (api.minimaxi.com), never the China-only
 .chat host. See ~/.claude/projects/.../memory/minimax_endpoint.md.
 """
 
+import http.client
 import json
 import os
+import random
 import re
+import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -19,6 +23,26 @@ CHAT_PATH = "/v1/text/chatcompletion_v2"
 # at ~181s before the server finished inference -- shadowing the wrapper's
 # watchdog and turning recoverable slow calls into both_failed exits.
 DEFAULT_TIMEOUT_S = 300
+
+# Kimi K2.6 provider (Anthropic-compatible /coding endpoint). Ported from
+# K2B's 2026-04-25 provider swap (commit ec2884a). MiniMax `2061` plan-tier
+# errors during a lapsed subscription leave K2Bi's code-review gate with no
+# fallback; the Kimi path keeps `/ship` working through any MiniMax outage.
+# Default `kimi`; flip back with K2B_LLM_PROVIDER=minimax when MiniMax is
+# the preferred reviewer.
+K2B_LLM_PROVIDER = os.environ.get("K2B_LLM_PROVIDER", "kimi").strip() or "kimi"
+KIMI_API_HOST = os.environ.get("KIMI_API_HOST", "https://api.kimi.com/coding")
+KIMI_MESSAGES_PATH = "/v1/messages"
+KIMI_DEFAULT_MODEL = os.environ.get("KIMI_DEFAULT_MODEL", "kimi-for-coding")
+
+# Retry constants (used only by the Kimi path -- K2Bi's existing MiniMax
+# branch is intentionally retry-free per its operational baseline; do not
+# backport retry to the MiniMax branch in this swap, that's a separate
+# scope).
+RETRY_HTTP_STATUSES = {502, 503, 504, 529}
+MAX_RETRIES = 3
+RETRY_BACKOFF_S = (10, 20, 40)
+RETRY_JITTER_MAX_S = 5.0
 
 
 class MinimaxError(RuntimeError):
@@ -44,6 +68,25 @@ def load_api_key() -> str:
     )
 
 
+def load_kimi_api_key() -> str:
+    key = os.environ.get("KIMI_API_KEY", "").strip()
+    if key:
+        return key
+    zshrc = Path.home() / ".zshrc"
+    if zshrc.exists():
+        match = re.search(
+            r'^\s*export\s+KIMI_API_KEY\s*=\s*"([^"]+)"',
+            zshrc.read_text(),
+            re.MULTILINE,
+        )
+        if match:
+            return match.group(1)
+    raise MinimaxError(
+        "KIMI_API_KEY not set and not found in ~/.zshrc. "
+        "Export it or set K2B_LLM_PROVIDER=minimax to fall back."
+    )
+
+
 def chat_completion(
     model: str,
     messages: list,
@@ -55,10 +98,26 @@ def chat_completion(
     response_format: dict | None = None,
     timeout: int = DEFAULT_TIMEOUT_S,
 ) -> dict:
-    """POST to chatcompletion_v2 and return the parsed JSON response.
+    """POST a chat-completion request and return the parsed JSON response.
+
+    Routes to Kimi K2.6 when K2B_LLM_PROVIDER=kimi (default since the K2B
+    2026-04-25 swap, ported here for K2Bi's review pipeline). Falls back
+    to MiniMax chatcompletion_v2 when K2B_LLM_PROVIDER=minimax.
+
+    Kimi responses are translated into the MiniMax chatcompletion_v2
+    envelope (choices[0].message.content / usage.{prompt,completion,total}_tokens
+    / base_resp.status_code=0) so downstream extract_assistant_text /
+    extract_token_usage callers keep working unchanged.
 
     Raises MinimaxError on transport, HTTP, or API-level errors.
     """
+    if K2B_LLM_PROVIDER == "kimi":
+        return _kimi_chat_completion(
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            timeout=timeout,
+        )
     api_key = load_api_key()
     payload: dict = {
         "model": model,
@@ -108,6 +167,140 @@ def chat_completion(
         )
 
     return parsed
+
+
+def _kimi_chat_completion(
+    messages: list,
+    *,
+    max_tokens: int,
+    temperature: float,
+    timeout: int,
+) -> dict:
+    """Call Kimi K2.6 at /coding/v1/messages and return the response in
+    MiniMax chatcompletion_v2 envelope shape.
+
+    Translation:
+      - System-role messages collapse into a single top-level `system`
+        field (Anthropic Messages API convention).
+      - `response_format` and `tools` / `tool_choice` are dropped (no
+        Anthropic equivalents in the simple Kimi-for-coding mode).
+      - Model id forced to KIMI_DEFAULT_MODEL regardless of caller's
+        request -- callers may still carry MiniMax-* ids from older code.
+    """
+    api_key = load_kimi_api_key()
+
+    system_parts = [m.get("content", "") for m in messages if m.get("role") == "system"]
+    non_system = [m for m in messages if m.get("role") != "system"]
+    payload: dict = {
+        "model": KIMI_DEFAULT_MODEL,
+        "max_tokens": max_tokens,
+        "messages": non_system,
+        "temperature": temperature,
+    }
+    if system_parts:
+        payload["system"] = "\n\n".join(s for s in system_parts if s)
+
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+    }
+    req = urllib.request.Request(
+        f"{KIMI_API_HOST}{KIMI_MESSAGES_PATH}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    last_err: Exception | None = None
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = resp.read().decode("utf-8")
+            break
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                detail = e.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+            if e.code in RETRY_HTTP_STATUSES and attempt < MAX_RETRIES:
+                wait_s = RETRY_BACKOFF_S[attempt] + random.uniform(0, RETRY_JITTER_MAX_S)
+                print(
+                    f"[kimi] HTTP {e.code} (transient) on attempt {attempt + 1}; "
+                    f"retrying in {wait_s:.1f}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                time.sleep(wait_s)
+                last_err = e
+                continue
+            raise MinimaxError(f"HTTP {e.code} from Kimi: {detail[:500]}") from e
+        except (urllib.error.URLError, http.client.HTTPException, ConnectionError, TimeoutError) as e:
+            # RemoteDisconnected (HTTPException subclass), connection
+            # resets, and socket timeouts all fall here. Kimi has occasional
+            # mid-stream drops under long prompts -- retry generously.
+            if attempt < MAX_RETRIES:
+                wait_s = RETRY_BACKOFF_S[attempt] + random.uniform(0, RETRY_JITTER_MAX_S)
+                print(
+                    f"[kimi] network error on attempt {attempt + 1}: {type(e).__name__}: {e}; "
+                    f"retrying in {wait_s:.1f}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                time.sleep(wait_s)
+                last_err = e
+                continue
+            raise MinimaxError(
+                f"Network error contacting Kimi after {MAX_RETRIES + 1} attempts: {e}"
+            ) from e
+    else:
+        raise MinimaxError(
+            f"Kimi unreachable after {MAX_RETRIES + 1} attempts; last error: {last_err}"
+        )
+
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError as e:
+        raise MinimaxError(f"Non-JSON response from Kimi: {body[:500]}") from e
+
+    if isinstance(parsed.get("error"), dict):
+        err = parsed["error"]
+        raise MinimaxError(
+            f"Kimi API error {err.get('type', '?')}: {err.get('message', 'unknown')}"
+        )
+
+    content_blocks = parsed.get("content") or []
+    assistant_text = "".join(
+        b.get("text", "") for b in content_blocks if b.get("type") == "text"
+    )
+    usage_raw = parsed.get("usage") or {}
+    # Kimi already emits OpenAI-style prompt_tokens/completion_tokens/total_tokens
+    # alongside its Anthropic-style input_tokens/output_tokens. Prefer the
+    # OpenAI-compat fields; fall back to computing from Anthropic fields.
+    usage = {
+        "prompt_tokens": usage_raw.get("prompt_tokens", usage_raw.get("input_tokens")),
+        "completion_tokens": usage_raw.get(
+            "completion_tokens", usage_raw.get("output_tokens")
+        ),
+        "total_tokens": usage_raw.get(
+            "total_tokens",
+            (usage_raw.get("input_tokens") or 0) + (usage_raw.get("output_tokens") or 0),
+        ),
+    }
+
+    return {
+        "id": parsed.get("id"),
+        "model": parsed.get("model", KIMI_DEFAULT_MODEL),
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": assistant_text},
+                "finish_reason": parsed.get("stop_reason") or "stop",
+            }
+        ],
+        "usage": usage,
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
 
 
 def extract_assistant_text(response: dict) -> str:

--- a/scripts/lib/minimax_review.py
+++ b/scripts/lib/minimax_review.py
@@ -6,6 +6,7 @@ Codex's review-output schema. Touches nothing in /ship or the codex plugin.
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -417,13 +418,21 @@ def extract_json_object(text: str) -> dict | None:
         return json.loads(text)
     except json.JSONDecodeError:
         pass
-    # Strip common code-fence wrappers
-    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    # Kimi wraps JSON in ```json ... ``` fences. Use json.JSONDecoder.raw_decode
+    # instead of a regex brace-match: raw_decode scans linearly with a real
+    # JSON parser, so it cannot catastrophic-backtrack on pathological input
+    # (the K2B 2026-04-25 swap flagged the prior greedy regex as a hang risk).
+    fence = re.search(r"```(?:json)?\s*", text)
     if fence:
-        try:
-            return json.loads(fence.group(1))
-        except json.JSONDecodeError:
-            pass
+        rest = text[fence.end():]
+        brace = rest.find("{")
+        if brace != -1:
+            try:
+                obj, _ = json.JSONDecoder().raw_decode(rest[brace:])
+                if isinstance(obj, dict):
+                    return obj
+            except json.JSONDecodeError:
+                pass
     # Greedy first-{ to last-} fallback
     start = text.find("{")
     end = text.rfind("}")
@@ -450,7 +459,7 @@ def render_markdown(parsed: dict, model: str, usage: dict) -> str:
 
     badge = "APPROVE" if verdict == "approve" else "NEEDS-ATTENTION"
     lines: list[str] = []
-    lines.append(f"# MiniMax {model} review -- {badge}")
+    lines.append(f"# {model} review -- {badge}")
     lines.append("")
     lines.append(f"**Summary:** {summary}")
     lines.append("")
@@ -558,10 +567,19 @@ def main() -> int:
         default=None,
         help="Comma-separated list of paths (required when --scope diff or files)",
     )
+    # Default model tracks the active provider: kimi-for-coding when
+    # K2B_LLM_PROVIDER=kimi (current default since the K2B 2026-04-25 swap),
+    # MiniMax-M2.7 on MiniMax rollback. Callers can still pass --model.
+    _default_model = os.environ.get(
+        "K2B_LLM_MODEL",
+        "kimi-for-coding"
+        if os.environ.get("K2B_LLM_PROVIDER", "kimi") == "kimi"
+        else "MiniMax-M2.7",
+    )
     parser.add_argument(
         "--model",
-        default="MiniMax-M2.7",
-        help="MiniMax model id (default MiniMax-M2.7)",
+        default=_default_model,
+        help=f"Model id (default {_default_model})",
     )
     parser.add_argument(
         "--focus",


### PR DESCRIPTION
## Summary

Mirrors the K2B 2026-04-25 swap ([kcyh7428/K2B@ec2884a](https://github.com/kcyh7428/K2B/commit/ec2884a)). MiniMax \`status_code 2061\` during a lapsed subscription leaves K2Bi's code-review gate with no working reviewer (Codex skips on EISDIR / quota; MiniMax fallback hits 2061). Kimi K2.6 via the \`/coding/v1/messages\` Anthropic-compatible endpoint replaces MiniMax for K2Bi's text path. Default \`kimi\`; flip back with \`K2B_LLM_PROVIDER=minimax\` when MiniMax is preferred.

K2Bi surface is smaller than K2B's: only \`scripts/lib/minimax_review.py\` calls \`chat_completion\`. The swap is therefore minimal -- 2 files, 221 insertions.

## What changed

- **\`scripts/lib/minimax_common.py\`**: \`K2B_LLM_PROVIDER\` switch + \`KIMI_*\` constants + \`load_kimi_api_key()\` + \`_kimi_chat_completion()\` with retry. Wire-format translation: OpenAI chatcompletion_v2 request -> Anthropic Messages, response -> chatcompletion_v2 envelope, so \`extract_assistant_text\` / \`extract_token_usage\` work unchanged.
- **\`scripts/lib/minimax_review.py\`**: default model resolves from env (\`kimi-for-coding\` when provider is kimi, \`MiniMax-M2.7\` on rollback). Markdown header provider-agnostic. JSON extraction uses \`json.JSONDecoder.raw_decode\` instead of a greedy regex (linear scan, no catastrophic backtracking).

## Verification

Ran \`scripts/minimax-review.sh --scope files --files scripts/lib/minimax_common.py --json --no-archive\` on this branch -- Kimi delivered a full structured JSON code review with no 2061 error. Same hardening findings as on the K2B side (already tracked in [K2B's feature_kimi-swap-hardening](https://github.com/kcyh7428/K2B/blob/main/../K2B-Vault/wiki/concepts/feature_kimi-swap-hardening.md) backlog item).

## Test plan

- [ ] \`KIMI_API_KEY\` exported in \`~/.zshrc\` (already set on Keith's MacBook from the K2B swap)
- [ ] \`scripts/minimax-review.sh --scope files --files <some-file>\` returns structured JSON via Kimi
- [ ] Set \`K2B_LLM_PROVIDER=minimax\` and confirm rollback path still hits MiniMax-M2.7 cleanly
- [ ] Run a full \`/ship\` on K2Bi with this branch as the active reviewer to validate the runner integration

## Notes

- K2Bi MiniMax branch intentionally kept retry-free per its existing operational baseline; retry added only to the Kimi path.
- \`MINIMAX_API_KEY\` requirement unchanged -- shared subscription with K2B for image / TTS / VLM (Kimi is text-only).
- Draft PR: opening for review, not for immediate merge. Merge after \`/ship\` integration sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)