### PR TITLE
fix(minimax-review): harden parser + validator against malformed-success (R1-R10)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,3 +1,45 @@
+## 2026-04-26 -- minimax-review parser + validator hardened against malformed-success (P3 follow-up from m2.22 triage)
+
+**Commit:** `00b3953` fix(minimax-review): harden review-output parser + validator against malformed-success
+
+**What shipped:** Closes the P3 follow-up surfaced in the m2.22 SHIPPED entry below. When a Kimi response was even slightly off-shape (early `\`\`\`json` stub before the real review, partial parse, embedded quotes that broke nested JSON, NaN confidence, extra schema keys, etc.), the previous parser would silently return a partial dict, the previous top-level-only validator would accept it, `main()` would exit 0, and `review_runner.py`'s rc=0-only verdict-marker gate at lines 368-382 would suppress the secondary-reviewer fallback. Real findings dropped on the floor with no signal that anything was wrong.
+
+Two-layer fix:
+1. `extract_json_object` now enforces a "whole-response is a single review object" contract: explicit `\`\`\`json` fence with a word boundary (rejects `jsonc` / `json5` / `python` / untagged hijacks); single-fence-only (multiple json fences = ambiguous); whitespace required before the fence, between the tag and `{`, after the parsed object up to the closing fence, and after the closing fence; greedy first-`{` to last-`}` fallback only runs for completely fence-free responses, and only when the JSON object is the entire response (no surrounding prose).
+2. `is_valid_review_object` now mirrors `review-output.schema.json`: top-level required (verdict enum, non-empty summary, list findings, list next_steps); each finding required (severity enum, non-empty title/body/file, strict-int line_start/line_end >= 1, finite-number confidence in [0,1], recommendation string); `additionalProperties: false` enforced via exact key-set comparison at both levels; NaN / +Inf / -Inf confidence rejected (Python's `json.loads` accepts them by default; NaN bypasses range checks silently).
+
+`main()` treats schema-invalid parses as unparseable (stderr warning naming missing fields, exit 3, raw text still archived for forensics). Wrapper's existing `rc != 0` fallback in `run_fallback_chain` triggers normally.
+
+**Codex review:** 10 review rounds (R1-R10) via `scripts/review.sh diff`. Each round Codex found a more contrived malformed-success path; each fix was implemented test-first. Final R10 verdict: APPROVE -- "No ship blocker found in the R10 diff. The parser now rejects the malformed-success classes raised through R1-R10, and the validator closes the remaining schema-shape gaps before rc=0 can suppress fallback."
+
+| Round | Finding | Severity | Fix |
+|-------|---------|----------|-----|
+| R1    | top-level-only validation accepted `findings: [{}]` | high | nested per-finding required + non-empty title/body/file + strict-int line bounds + numeric confidence |
+| R2    | additionalProperties not enforced + NaN bypassed range check | high | exact key-set comparison + math.isfinite |
+| R3    | trailing garbage in fence accepted via raw_decode | high | trailing-whitespace check; reject when fence found but malformed |
+| R4    | `\`\`\`(?:json)?` matched python fences | high | require explicit `json` tag |
+| R5    | `\`\`\`json\s*` prefix-matched `jsonc` / `json5` | high | word-boundary `\b` |
+| R6    | first valid json fence won when later fence had real review | high | reject when multiple json fences |
+| R7    | greedy fallback parsed schema-stub from non-json fences | high | skip greedy if any backtick fence in text |
+| R8    | trailing prose after closing fence accepted | high | require post-fence + post-greedy whitespace |
+| R9    | leading prose before json fence + between tag and `{` | high | require pre-fence + intra-fence whitespace |
+| R10   | (final) | approve | no material findings |
+
+**Tests added:** 45 new in `tests/test_minimax_review_scope.py`. Targeted file green: 64/64.
+
+**Feature status change:** review-pipeline correctness gate hardened. The `scripts/review.sh` -> `scripts/lib/review_runner.py` -> `scripts/lib/minimax_review.py` chain can no longer rc=0 on a malformed Kimi response.
+
+**Follow-ups:** None. Codex flagged this as a deferred P3 in the m2.22 SHIPPED entry; this commit closes that thread.
+
+**Key decisions:**
+- Strict whole-response policy chosen over lenient "extract first valid review" because the threat model prefers false-negative (reject and retry on secondary reviewer) over false-positive (accept malformed and silently drop content).
+- `--no-feature` ship -- this is review-pipeline infrastructure, not a phase milestone or feature note.
+- m2.22 commits (9b0f0b3 + 3c98417 + dbee41f + 317cdba + 4edc67f) untouched, per the architect's parallel-session deferral instruction.
+
+**Related:** L-2026-04-26-002 (env-prefix gotcha that already touched the neighbour `scripts/review.sh`).
+
+---
+
 ## 2026-04-26 -- m2.22 Codex full-stack review SHIPPED -- closes Bundle 5 (5/5), unblocks Phase 3.10 burn-in window
 
 **Commits:** `9b0f0b3` fix(m2.22-review): F1-F4 + `3c98417` fix(m2.22-review-r2): N1+N2 + `dbee41f` fix(m2.22-review-r3): N3 + `317cdba` fix(m2.22-review-r4): N4

--- a/scripts/lib/minimax_review.py
+++ b/scripts/lib/minimax_review.py
@@ -6,6 +6,7 @@ Codex's review-output schema. Touches nothing in /ship or the codex plugin.
 
 import argparse
 import json
+import math
 import os
 import re
 import subprocess
@@ -410,7 +411,19 @@ def build_prompt(target_label: str, focus: str, content: str, schema_text: str) 
 
 
 def extract_json_object(text: str) -> dict | None:
-    """Try strict json.loads first, then regex-extract the first {...} block."""
+    """Try strict json.loads first, then regex-extract the first {...} block.
+
+    The fence path uses json.JSONDecoder.raw_decode (instead of a greedy
+    regex brace-match) to avoid catastrophic backtracking on pathological
+    input -- the K2B 2026-04-25 swap flagged the prior greedy regex as
+    a hang risk. raw_decode returns the first valid JSON value and the
+    index where it stopped; we then verify the rest of the fenced
+    payload (up to the closing ```) is whitespace. Trailing garbage or
+    a second concatenated object inside the same fence is rejected
+    here so the wrapper can fall through to the secondary reviewer
+    instead of accepting the prefix as the whole review (Codex R4
+    flagged this as a malformed-success class still open after R3).
+    """
     text = text.strip()
     if not text:
         return None
@@ -418,30 +431,181 @@ def extract_json_object(text: str) -> dict | None:
         return json.loads(text)
     except json.JSONDecodeError:
         pass
-    # Kimi wraps JSON in ```json ... ``` fences. Use json.JSONDecoder.raw_decode
-    # instead of a regex brace-match: raw_decode scans linearly with a real
-    # JSON parser, so it cannot catastrophic-backtrack on pathological input
-    # (the K2B 2026-04-25 swap flagged the prior greedy regex as a hang risk).
-    fence = re.search(r"```(?:json)?\s*", text)
-    if fence:
+    # Locate explicit `json` fences. Word-boundary `\b` keeps the
+    # match strictly to the `json` tag so `jsonc` / `json5` (Codex R5)
+    # and untagged or alternate-language fences (R5/R6) do not match.
+    # Multiple `json` fences in one response (Codex R7) are ambiguous:
+    # Kimi outputting two reviews -- whether disagreeing drafts or a
+    # duplicate -- is itself a malformed-success signal that the
+    # wrapper should fall through on.
+    fence_iter = list(re.finditer(r"```json\b\s*", text))
+    if len(fence_iter) > 1:
+        return None
+    if len(fence_iter) == 1:
+        fence = fence_iter[0]
+        # R10: content before the opening ```json fence must be
+        # whitespace. Leading prose could contain real review content
+        # the parser would otherwise silently drop.
+        if text[: fence.start()].strip():
+            return None
         rest = text[fence.end():]
         brace = rest.find("{")
         if brace != -1:
+            # R10: content between the fence tag and the opening `{`
+            # must also be whitespace -- the prompt's contract is
+            # "no prose before or after the JSON object", which
+            # extends to inside the fence.
+            if rest[:brace].strip():
+                return None
             try:
-                obj, _ = json.JSONDecoder().raw_decode(rest[brace:])
-                if isinstance(obj, dict):
-                    return obj
+                obj, idx = json.JSONDecoder().raw_decode(rest[brace:])
             except json.JSONDecodeError:
-                pass
-    # Greedy first-{ to last-} fallback
+                obj = None
+            if isinstance(obj, dict):
+                trailing = rest[brace + idx:]
+                close = trailing.find("```")
+                if close != -1:
+                    fenced_remainder = trailing[:close]
+                    after_close = trailing[close + 3 :]
+                else:
+                    fenced_remainder = trailing
+                    after_close = ""
+                # R4: payload up to closing fence must be whitespace.
+                # R9: content after closing fence must also be
+                # whitespace -- the prompt's contract says "no prose
+                # before or after the JSON object", so trailing prose
+                # could contain real review content the parser would
+                # otherwise silently drop.
+                if (
+                    not fenced_remainder.strip()
+                    and not after_close.strip()
+                ):
+                    return obj
+        # The single json-tagged fence existed but its payload was
+        # malformed (parse error, non-dict, or trailing garbage). Do
+        # NOT salvage via the greedy first-{ to last-} fallback -- the
+        # greedy search ignores text between brace positions, which is
+        # exactly the gap Codex R4 flagged: it would re-accept a valid
+        # prefix and silently drop whatever Kimi appended.
+        return None
+    # No json-tagged fence. If ANY backtick fence exists in the
+    # response (e.g. ``` ```python ... ``` ```), do NOT salvage with
+    # greedy: Codex R8 flagged that a schema-shaped stub inside a
+    # non-JSON fence would otherwise be accepted as the review. Greedy
+    # is only safe for completely fence-free responses, and (R9)
+    # only when the JSON object is the entire response -- prose
+    # before or after could contain real review content.
+    if "```" in text:
+        return None
     start = text.find("{")
     end = text.rfind("}")
     if start != -1 and end != -1 and end > start:
+        if text[:start].strip() or text[end + 1 :].strip():
+            # R9: surrounding prose violates the prompt's
+            # "no prose before or after" contract.
+            return None
         try:
             return json.loads(text[start : end + 1])
         except json.JSONDecodeError:
             return None
     return None
+
+
+_FINDING_SEVERITIES = ("critical", "high", "medium", "low")
+_REVIEW_TOP_KEYS = frozenset({"verdict", "summary", "findings", "next_steps"})
+_FINDING_KEYS = frozenset(
+    {
+        "severity", "title", "body", "file",
+        "line_start", "line_end", "confidence", "recommendation",
+    }
+)
+
+
+def _is_strict_int(x: object) -> bool:
+    # bool is an int subclass in Python; the JSON schema's `integer`
+    # type does not match booleans.
+    return isinstance(x, int) and not isinstance(x, bool)
+
+
+def _is_strict_finite_number(x: object) -> bool:
+    # Python's json.loads accepts NaN / Infinity by default. NaN
+    # silently bypasses range checks (any comparison with NaN is False),
+    # so confidence must be explicitly finite to satisfy the schema.
+    if not isinstance(x, (int, float)) or isinstance(x, bool):
+        return False
+    return math.isfinite(x)
+
+
+def _is_valid_finding(f: object) -> bool:
+    if not isinstance(f, dict):
+        return False
+    # additionalProperties: false in the schema -- exact key set.
+    if set(f.keys()) != _FINDING_KEYS:
+        return False
+    if f.get("severity") not in _FINDING_SEVERITIES:
+        return False
+    for key in ("title", "body", "file"):
+        v = f.get(key)
+        if not isinstance(v, str) or not v.strip():
+            return False
+    for key in ("line_start", "line_end"):
+        v = f.get(key)
+        if not _is_strict_int(v) or v < 1:
+            return False
+    conf = f.get("confidence")
+    if not _is_strict_finite_number(conf) or conf < 0 or conf > 1:
+        return False
+    if not isinstance(f.get("recommendation"), str):
+        return False
+    return True
+
+
+def is_valid_review_object(parsed: object) -> bool:
+    """Return True iff parsed matches review-output.schema.json's required shape.
+
+    Without this check, the fence path's json.JSONDecoder.raw_decode can
+    return a partial dict (e.g. an early ```json stub before the real
+    review, or a truncated response that fences only
+    `{"verdict": "approve"}`) that renders as a successful empty review
+    and exits 0. The wrapper's quality gate at review_runner.py:368-382
+    only checks for verdict markers on rc=0, so a malformed-success
+    suppresses the Kimi <-> Codex fallback entirely.
+
+    Mirrors review-output.schema.json including `additionalProperties: false`
+    at both levels. Top-level keys must be exactly `_REVIEW_TOP_KEYS`;
+    each finding must have exactly `_FINDING_KEYS`. Required types:
+    verdict (enum), summary (non-empty string), findings (list of
+    valid items), next_steps (list of non-empty strings). Confidence
+    must be a finite number in [0, 1] -- NaN / Infinity are explicitly
+    rejected (json.loads accepts both, and NaN bypasses range checks).
+    An empty findings or next_steps list is fine -- a real "approve,
+    no findings" review still passes; only schema-violating entries
+    trip this.
+
+    Review history (Codex):
+      R1 -- top-level-only check accepted `findings: [{}]` (HIGH)
+      R2 -- nested item check accepted extra keys + NaN confidence (HIGH)
+    """
+    if not isinstance(parsed, dict):
+        return False
+    if set(parsed.keys()) != _REVIEW_TOP_KEYS:
+        return False
+    if parsed.get("verdict") not in ("approve", "needs-attention"):
+        return False
+    summary = parsed.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        return False
+    findings = parsed.get("findings")
+    if not isinstance(findings, list):
+        return False
+    if any(not _is_valid_finding(f) for f in findings):
+        return False
+    next_steps = parsed.get("next_steps")
+    if not isinstance(next_steps, list):
+        return False
+    if any(not isinstance(s, str) or not s.strip() for s in next_steps):
+        return False
+    return True
 
 
 SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
@@ -713,6 +877,17 @@ def main() -> int:
         )
         append_usage_log(archive_dir, args.model, args.scope, usage)
         print(f"[minimax-review] archived: {out.relative_to(REPO_ROOT)}", file=sys.stderr)
+
+    parsed_is_partial = parsed is not None and not is_valid_review_object(parsed)
+    if parsed_is_partial:
+        print(
+            "[minimax-review] parsed JSON is missing required review fields "
+            "(verdict/summary/findings/next_steps); treating as unparseable "
+            "so the wrapper falls through to the secondary reviewer. "
+            "See archive for raw output.",
+            file=sys.stderr,
+        )
+        parsed = None
 
     if parsed is None:
         print(

--- a/tests/test_minimax_review_scope.py
+++ b/tests/test_minimax_review_scope.py
@@ -23,10 +23,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
 
 from minimax_review import (  # noqa: E402
+    extract_json_object,
     gather_diff_scoped_context,
     gather_file_list_context,
     gather_plan_context,
     gather_working_tree_context,
+    is_valid_review_object,
 )
 
 
@@ -393,6 +395,621 @@ class CLIDispatch(unittest.TestCase):
             self.assertEqual(res.returncode, 0)
             self.assertIn("no working-tree changes", res.stderr)
             self.assertIn("gathering working-tree context", res.stderr)
+
+
+class JSONExtractionValidation(unittest.TestCase):
+    """Regression: a partial JSON parse must NOT silently exit 0 with
+    `findings: []`.
+
+    Codex flagged this twice during the m2.22 review window. The fence
+    path uses json.JSONDecoder.raw_decode, which stops at the end of
+    the first valid JSON value -- so an early ```json stub before the
+    real review, or a truncated response that fences only
+    `{"verdict": "approve"}`, parses successfully and renders as a
+    successful empty review. The wrapper's quality gate at
+    review_runner.py:368-382 only checks for verdict markers on rc=0,
+    so the malformed-success suppresses the secondary-reviewer fallback.
+
+    The fix: validate the parsed object has the schema-required fields
+    (verdict + summary + findings + next_steps) before treating it as
+    a review. Invalid -> treat as unparseable, exit non-zero, let the
+    wrapper fall through.
+    """
+
+    def test_early_fence_stub_with_later_real_review_returns_none(self) -> None:
+        """The original R1 bug: an early ```json stub followed by a
+        later ```json review used to silently drop the real review.
+        After R7 (multiple ```json fences are ambiguous),
+        extract_json_object rejects the entire response so the
+        wrapper falls through to the secondary reviewer."""
+        text = (
+            "Let me start the review.\n\n"
+            "```json\n"
+            '{"verdict": "approve"}\n'
+            "```\n\n"
+            "Wait, on second look I have findings:\n\n"
+            "```json\n"
+            '{"verdict": "needs-attention", "summary": "real review", '
+            '"findings": [{"severity": "high", "title": "X", '
+            '"body": "detail", "file": "a.py", "line_start": 1, '
+            '"line_end": 2, "confidence": 0.9, "recommendation": "fix"}], '
+            '"next_steps": []}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_validator_rejects_verdict_only_stub(self) -> None:
+        self.assertFalse(is_valid_review_object({"verdict": "approve"}))
+
+    def test_validator_rejects_missing_findings(self) -> None:
+        self.assertFalse(
+            is_valid_review_object(
+                {
+                    "verdict": "approve",
+                    "summary": "looks good",
+                    "next_steps": [],
+                }
+            )
+        )
+
+    def test_validator_rejects_missing_summary(self) -> None:
+        self.assertFalse(
+            is_valid_review_object(
+                {
+                    "verdict": "approve",
+                    "findings": [],
+                    "next_steps": [],
+                }
+            )
+        )
+
+    def test_validator_rejects_unknown_verdict(self) -> None:
+        self.assertFalse(
+            is_valid_review_object(
+                {
+                    "verdict": "unparseable",
+                    "summary": "?",
+                    "findings": [],
+                    "next_steps": [],
+                }
+            )
+        )
+
+    def test_validator_rejects_non_list_findings(self) -> None:
+        self.assertFalse(
+            is_valid_review_object(
+                {
+                    "verdict": "approve",
+                    "summary": "ok",
+                    "findings": "none",
+                    "next_steps": [],
+                }
+            )
+        )
+
+    def test_validator_accepts_empty_findings(self) -> None:
+        self.assertTrue(
+            is_valid_review_object(
+                {
+                    "verdict": "approve",
+                    "summary": "no issues",
+                    "findings": [],
+                    "next_steps": [],
+                }
+            )
+        )
+
+    def test_validator_accepts_full_review(self) -> None:
+        self.assertTrue(
+            is_valid_review_object(
+                {
+                    "verdict": "needs-attention",
+                    "summary": "found issues",
+                    "findings": [
+                        {
+                            "severity": "high",
+                            "title": "X",
+                            "body": "detail",
+                            "file": "a.py",
+                            "line_start": 1,
+                            "line_end": 2,
+                            "confidence": 0.9,
+                            "recommendation": "fix",
+                        }
+                    ],
+                    "next_steps": ["follow up"],
+                }
+            )
+        )
+
+    # R2 (Codex post-commit review): top-level shape is not enough.
+    # The fence path's raw_decode could land on a payload whose findings
+    # items are empty objects or whose next_steps items are empty
+    # strings, and the previous validator passed it -- which still hits
+    # the wrapper's verdict-marker gate at rc=0 and skips fallback.
+    # Mirror the schema's nested `required` for findings items and the
+    # `minLength: 1` constraint for next_steps items.
+
+    def _full_finding(self, **overrides: object) -> dict:
+        base = {
+            "severity": "high",
+            "title": "X",
+            "body": "detail",
+            "file": "a.py",
+            "line_start": 1,
+            "line_end": 2,
+            "confidence": 0.9,
+            "recommendation": "fix",
+        }
+        base.update(overrides)
+        return base
+
+    def _wrap(self, **overrides: object) -> dict:
+        base = {
+            "verdict": "needs-attention",
+            "summary": "ok",
+            "findings": [self._full_finding()],
+            "next_steps": ["next"],
+        }
+        base.update(overrides)
+        return base
+
+    def test_validator_rejects_empty_finding_object(self) -> None:
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[{}])))
+
+    def test_validator_rejects_finding_missing_one_required_field(self) -> None:
+        partial = self._full_finding()
+        del partial["body"]
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[partial])))
+
+    def test_validator_rejects_finding_with_invalid_severity(self) -> None:
+        bad = self._full_finding(severity="weak")
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_finding_with_empty_title(self) -> None:
+        bad = self._full_finding(title="")
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_finding_with_non_int_line_start(self) -> None:
+        bad = self._full_finding(line_start="1")
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_finding_with_zero_line_start(self) -> None:
+        bad = self._full_finding(line_start=0)
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_finding_with_out_of_range_confidence(self) -> None:
+        bad = self._full_finding(confidence=1.5)
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_finding_with_negative_confidence(self) -> None:
+        bad = self._full_finding(confidence=-0.1)
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_finding_with_non_dict_item(self) -> None:
+        self.assertFalse(
+            is_valid_review_object(self._wrap(findings=["not-a-dict"]))
+        )
+
+    def test_validator_rejects_empty_next_step_string(self) -> None:
+        self.assertFalse(is_valid_review_object(self._wrap(next_steps=[""])))
+
+    def test_validator_rejects_non_string_next_step(self) -> None:
+        self.assertFalse(is_valid_review_object(self._wrap(next_steps=[1])))
+
+    def test_validator_accepts_int_confidence_in_range(self) -> None:
+        # Schema allows number; an int in [0,1] is valid (e.g. 1).
+        good = self._full_finding(confidence=1)
+        self.assertTrue(is_valid_review_object(self._wrap(findings=[good])))
+
+    # R3 (Codex post-R2 review): two more soundness gaps.
+    # 1. The schema sets additionalProperties: false at both the top
+    #    level and inside each finding -- extra keys are schema
+    #    violations and should fail validation.
+    # 2. Python's json.loads accepts NaN / Infinity by default; both
+    #    `NaN < 0` and `NaN > 1` are false, so the [0,1] range check
+    #    silently lets non-finite confidences through.
+
+    def test_validator_rejects_extra_top_level_key(self) -> None:
+        bad = self._wrap()
+        bad["extra"] = "not allowed"
+        self.assertFalse(is_valid_review_object(bad))
+
+    def test_validator_rejects_extra_finding_key(self) -> None:
+        bad = self._full_finding()
+        bad["extra"] = "not allowed"
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_nan_confidence(self) -> None:
+        bad = self._full_finding(confidence=float("nan"))
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_inf_confidence(self) -> None:
+        bad = self._full_finding(confidence=float("inf"))
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    def test_validator_rejects_negative_inf_confidence(self) -> None:
+        bad = self._full_finding(confidence=float("-inf"))
+        self.assertFalse(is_valid_review_object(self._wrap(findings=[bad])))
+
+    # R4 (Codex post-R3 review): the fence path's raw_decode returns
+    # the FIRST valid JSON object inside ```json ... ``` and ignores
+    # everything after it within the same fence. So trailing garbage
+    # or two concatenated objects in one fence still parses to the
+    # first object, which is a malformed-success path even after the
+    # validator hardening. Require the rest of the fenced payload to
+    # be whitespace.
+
+    def test_fence_with_clean_payload_still_parses(self) -> None:
+        text = (
+            "```json\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n"
+        )
+        parsed = extract_json_object(text)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.get("verdict"), "approve")
+
+    def test_fence_with_prose_after_closing_fence_returns_none(self) -> None:
+        # R9: Codex flagged that prose after the closing fence could
+        # contain real review content the parser would silently drop.
+        # Per the prompt's "no prose before or after the JSON object"
+        # contract, anything but whitespace after the closing fence
+        # rejects the parse so the wrapper falls through.
+        text = (
+            "```json\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n"
+            "Some prose after the closing fence is NOT allowed.\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_fence_with_trailing_garbage_inside_fence_returns_none(self) -> None:
+        text = (
+            "```json\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n'
+            "BROKEN trailing garbage inside the fence\n"
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_fence_with_two_concatenated_objects_returns_none(self) -> None:
+        text = (
+            "```json\n"
+            '{"verdict":"approve"}\n'
+            '{"verdict":"needs-attention","summary":"x","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    # R5 (Codex post-R4 review): the fence regex matched
+    # `\`\`\`(?:json)?` -- the `json` tag was optional, so an earlier
+    # ``` ```python ... ``` `` block containing a schema-shaped stub
+    # could hijack extraction even when a later real ``` ```json ```
+    # block contained the actual review. Require an explicit `json`
+    # tag so non-JSON fenced blocks are skipped.
+
+    def test_python_fence_then_json_review_returns_none_after_r10(
+        self,
+    ) -> None:
+        # Originally R5 made this case parse the real json review. R10
+        # tightened further: ANY non-whitespace before the ```json
+        # fence rejects, so a preceding python fence (with or without
+        # a stub inside) now causes the whole response to fail. The
+        # wrapper falls through to the secondary reviewer.
+        text = (
+            "```python\n"
+            '# example output:\n'
+            '# {"verdict":"approve","summary":"stub","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n\n"
+            "Real review:\n\n"
+            "```json\n"
+            '{"verdict":"needs-attention","summary":"real","findings":[],'
+            '"next_steps":["follow up"]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_no_fence_inline_json_with_prose_returns_none_strict(self) -> None:
+        # R5 originally allowed this; R9 tightened to require the
+        # response to be only the JSON (with optional whitespace).
+        text = (
+            'Here is the review: {"verdict":"approve","summary":"ok",'
+            '"findings":[],"next_steps":[]} -- end.'
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    # R6 (Codex post-R5 review): the fence regex `\`\`\`json\s*` was
+    # still a prefix match -- `\s*` consumes zero chars, so it matched
+    # `\`\`\`jsonc` and `\`\`\`json5` and the parser would scan into
+    # the wrong fence. Require a word boundary after `json`.
+
+    def test_jsonc_fence_then_json_review_returns_none_after_r10(
+        self,
+    ) -> None:
+        # Originally R6 (word-boundary fix) made this parse the json
+        # review, skipping the jsonc prefix. R10 tightened further:
+        # any leading content rejects.
+        text = (
+            "```jsonc\n"
+            '// example:\n'
+            '{"verdict":"approve","summary":"stub","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n\n"
+            "Real review:\n\n"
+            "```json\n"
+            '{"verdict":"needs-attention","summary":"real","findings":[],'
+            '"next_steps":["follow up"]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_json5_fence_then_json_review_returns_none_after_r10(
+        self,
+    ) -> None:
+        text = (
+            "```json5\n"
+            '{"verdict":"approve","summary":"stub","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n\n"
+            "```json\n"
+            '{"verdict":"needs-attention","summary":"real","findings":[],'
+            '"next_steps":["follow up"]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_json_fence_with_no_trailing_whitespace_still_parses(self) -> None:
+        # Edge case: `\`\`\`json{...}` with no whitespace between the
+        # tag and the `{`. Word-boundary `\b` matches at the json/{
+        # transition, so this is still treated as a json fence.
+        text = '```json{"verdict":"approve","summary":"ok","findings":[],"next_steps":[]}```'
+        parsed = extract_json_object(text)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.get("verdict"), "approve")
+
+    # R7 (Codex post-R6 review): the first valid `\`\`\`json` fence
+    # still won unconditionally, even when a later `\`\`\`json` fence
+    # held the real review (e.g. Kimi self-corrects: writes a draft,
+    # then writes a real one). Ambiguity must trigger fallback.
+
+    def test_two_json_fences_disagreeing_returns_none(self) -> None:
+        text = (
+            "```json\n"
+            '{"verdict":"approve","summary":"draft","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n\n"
+            "Actually, on reflection:\n\n"
+            "```json\n"
+            '{"verdict":"needs-attention","summary":"real","findings":[],'
+            '"next_steps":["follow up"]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_two_json_fences_identical_still_returns_none(self) -> None:
+        # Even if both fences contain the same JSON, the duplication
+        # is itself a malformed-success signal. Reject.
+        body = (
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}'
+        )
+        text = f"```json\n{body}\n```\n\n```json\n{body}\n```\n"
+        self.assertIsNone(extract_json_object(text))
+
+    def test_single_json_fence_with_leading_non_json_fence_returns_none(
+        self,
+    ) -> None:
+        # Pre-R10 this passed (json fence after python fence parsed).
+        # R10 strict policy: leading content before the json fence
+        # rejects.
+        text = (
+            "```python\n"
+            "print('hello')\n"
+            "```\n\n"
+            "```json\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    # R8 (Codex post-R7 review): the greedy first-{ to last-} fallback
+    # runs when there are zero `\`\`\`json` fences, but the response
+    # may still contain a schema-shaped stub inside a non-JSON fence
+    # (e.g. ``` ```python ... {stub} ... ``` ```). Greedy would parse
+    # the stub and the validator would accept it. Skip greedy
+    # whenever any backtick fence exists -- inline-JSON-with-prose is
+    # still allowed when no fence is present.
+
+    def test_python_fence_stub_with_no_json_fence_returns_none(self) -> None:
+        text = (
+            "```python\n"
+            '# example output:\n'
+            '{"verdict":"approve","summary":"stub","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n\n"
+            "Real review in prose: I see no issues.\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_no_fence_inline_json_with_prose_returns_none(self) -> None:
+        # R9: Codex flagged that surrounding prose could contain real
+        # review content. Strict policy: only whole-response JSON
+        # (no fences, no prose) parses via the greedy path; anything
+        # else rejects so the wrapper falls through.
+        text = (
+            "Here is my review.\n\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n\n'
+            "Hope that helps!\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_no_fence_pure_json_response_still_works(self) -> None:
+        # R9 sanity: response that is just JSON (with optional
+        # surrounding whitespace, the prompt's expected output shape)
+        # still parses cleanly via strict json.loads.
+        text = (
+            '\n  {"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n  '
+        )
+        parsed = extract_json_object(text)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.get("verdict"), "approve")
+
+    # R10 (Codex post-R9 review): the fenced path also accepted
+    # leading prose -- both before the ```json fence and between the
+    # tag and the opening brace. Whole-response policy: leading
+    # content must be whitespace too.
+
+    def test_fence_with_prose_before_opening_fence_returns_none(self) -> None:
+        text = (
+            "Intro text describing what's about to come.\n\n"
+            "```json\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_fence_with_prose_between_tag_and_brace_returns_none(self) -> None:
+        text = (
+            "```json\n"
+            "// preamble inside the fence before the JSON\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n'
+            "```\n"
+        )
+        self.assertIsNone(extract_json_object(text))
+
+    def test_fence_with_only_whitespace_before_opens_still_parses(self) -> None:
+        text = (
+            "\n  \n"
+            "```json\n"
+            '{"verdict":"approve","summary":"ok","findings":[],'
+            '"next_steps":[]}\n'
+            "```"
+        )
+        parsed = extract_json_object(text)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.get("verdict"), "approve")
+
+
+class MainExitCodeOnPartialParse(unittest.TestCase):
+    """End-to-end: feed the script a malformed Kimi response that contains
+    a valid verdict marker, and assert it does NOT exit 0 with
+    findings: []. This is the architect's regression guard for the
+    R3-r3 / R4-r4 finding -- if the script exits 0, the wrapper's
+    quality gate at review_runner.py:368-382 sees `"verdict"` in the
+    log and skips the Kimi <-> Codex fallback entirely, dropping all
+    real findings on the floor.
+    """
+
+    SCRIPT = REPO_ROOT / "scripts" / "lib" / "minimax_review.py"
+
+    def _run_with_mocked_response(
+        self,
+        raw_response: str,
+        cwd: Path,
+    ) -> subprocess.CompletedProcess:
+        """Run main() with chat_completion patched to return raw_response.
+
+        `python3 script.py` puts the script's directory at sys.path[0]
+        before PYTHONPATH entries, so a shadow-import shim does not
+        actually shadow. Instead we write a small runner that imports
+        minimax_review and rebinds the in-module chat_completion symbol
+        before calling main(). Cwd is the tmp fixture repo so the
+        module-level `git rev-parse --show-toplevel` lands on it.
+        """
+        lib_dir = REPO_ROOT / "scripts" / "lib"
+        runner = cwd / "_test_runner.py"
+        canned = {
+            "id": "stub",
+            "choices": [{"message": {"content": raw_response}}],
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            },
+        }
+        runner.write_text(
+            "import json\n"
+            "import sys\n"
+            f"sys.path.insert(0, {str(lib_dir)!r})\n"
+            "import minimax_review\n"
+            f"_CANNED = {json.dumps(canned)}\n"
+            "def _fake_chat(*args, **kwargs):\n"
+            "    return _CANNED\n"
+            "minimax_review.chat_completion = _fake_chat\n"
+            "sys.argv = ['minimax_review.py'] + sys.argv[1:]\n"
+            "sys.exit(minimax_review.main())\n"
+        )
+        return subprocess.run(
+            [
+                sys.executable,
+                str(runner),
+                "--scope",
+                "working-tree",
+                "--no-archive",
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+
+    def test_partial_parse_with_verdict_marker_is_not_exit_0(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            build_fixture_repo(tmp_path)
+            # Malformed Kimi response: an early fenced verdict-only stub
+            # followed by what was supposed to be the real review with
+            # embedded quotes that break the JSON. The first fence
+            # parses cleanly via raw_decode and would silently win
+            # without the new validator.
+            raw = (
+                "Starting review.\n\n"
+                "```json\n"
+                '{"verdict": "approve"}\n'
+                "```\n\n"
+                "Actually, more findings:\n\n"
+                "```json\n"
+                '{"verdict": "needs-attention", "summary": "real review", '
+                '"findings": [{"severity": "high", "title": "Quote issue", '
+                '"body": "Code has "embedded" quotes", "file": "a.py", '
+                '"line_start": 1, "line_end": 2, "confidence": 0.8, '
+                '"recommendation": "escape them"}], "next_steps": []}\n'
+                "```\n"
+            )
+            res = self._run_with_mocked_response(raw, tmp_path)
+            self.assertNotEqual(
+                res.returncode,
+                0,
+                f"script exited 0 on partial-parse with verdict marker; "
+                f"this would suppress the wrapper's secondary-reviewer "
+                f"fallback. stdout={res.stdout!r} stderr={res.stderr!r}",
+            )
+
+    def test_truncated_verdict_only_response_is_not_exit_0(self) -> None:
+        """If max_tokens cuts the response off after just the verdict,
+        we must still not return success with empty findings."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            build_fixture_repo(tmp_path)
+            raw = "```json\n" '{"verdict": "approve"}\n' "```\n"
+            res = self._run_with_mocked_response(raw, tmp_path)
+            self.assertNotEqual(
+                res.returncode,
+                0,
+                f"script exited 0 on truncated verdict-only response; "
+                f"stdout={res.stdout!r} stderr={res.stderr!r}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Closes the P3 follow-up flagged in the [m2.22 SHIPPED DEVLOG entry](https://github.com/kcstudio/K2Bi/blob/main/DEVLOG.md): when a Kimi response was even slightly off-shape (early ```json stub, partial parse, embedded quotes, NaN confidence, extra schema keys, etc.), the previous parser silently returned a partial dict, the previous top-level-only validator accepted it, `main()` exited 0, and `review_runner.py`'s rc=0-only verdict-marker gate suppressed the secondary-reviewer fallback. Real findings dropped on the floor with no signal that anything was wrong.
- Two-layer fix in [scripts/lib/minimax_review.py](scripts/lib/minimax_review.py): (1) `extract_json_object` now enforces a strict whole-response contract -- explicit ```json fence with word boundary, single fence only, whitespace required before / between / inside / after, greedy fallback only for fence-free pure-JSON; (2) `is_valid_review_object` now mirrors `review-output.schema.json` including nested per-finding required, `additionalProperties: false` at both levels, and finite-number confidence (rejects NaN / +Inf / -Inf which `json.loads` accepts by default).
- 10 Codex review rounds (R1-R10) via `scripts/review.sh diff`. Each round Codex found a more contrived malformed-success path; each fix was implemented test-first. **Final R10 verdict: APPROVE** -- "No ship blocker found in the R10 diff. The parser now rejects the malformed-success classes raised through R1-R10, and the validator closes the remaining schema-shape gaps before rc=0 can suppress fallback."
- m2.22 commits (`9b0f0b3` + `3c98417` + `dbee41f` + `317cdba` + `4edc67f`) untouched per the architect's parallel-session deferral instruction.

## Test plan
- [x] 45 new tests in [tests/test_minimax_review_scope.py](tests/test_minimax_review_scope.py) (10 R1, 11 R2, 5 R3, 4 R4, 3 R5, 3 R6, 3 R7, 2 R8, 1 R9, 3 R10 + 2 end-to-end subprocess tests with `chat_completion` stubbed)
- [x] Targeted file green: 64/64 (`pytest -q tests/test_minimax_review_scope.py`)
- [x] Codex adversarial review approves (10 rounds; archive in `.code-reviews/`)
- [ ] Merge to `main`, then run `/sync` -- the `.pending-sync/20260426T092925_565a5af_1a0cd4f0.json` mailbox entry queues the deploy of `scripts/lib/minimax_review.py` + `DEVLOG.md` to the Hostinger VPS

## Codex review history
| Round | Finding | Severity | Fix |
|-------|---------|----------|-----|
| R1    | top-level-only validation accepted ``findings: [{}]`` | high | nested per-finding required + non-empty title/body/file + strict-int line bounds + numeric confidence |
| R2    | additionalProperties not enforced + NaN bypassed range check | high | exact key-set comparison + math.isfinite |
| R3    | trailing garbage in fence accepted via raw_decode | high | trailing-whitespace check; reject when fence found but malformed |
| R4    | ``\`\`\`(?:json)?`` matched python fences | high | require explicit ``json`` tag |
| R5    | ``\`\`\`json\s*`` prefix-matched ``jsonc`` / ``json5`` | high | word-boundary ``\b`` |
| R6    | first valid json fence won when later fence had real review | high | reject when multiple json fences |
| R7    | greedy fallback parsed schema-stub from non-json fences | high | skip greedy if any backtick fence in text |
| R8    | trailing prose after closing fence accepted | high | require post-fence + post-greedy whitespace |
| R9    | leading prose before json fence + between tag and ``{`` | high | require pre-fence + intra-fence whitespace |
| R10   | (final)         | approve | no material findings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)