### PR TITLE
fix(engine-recovery): Q42 +1 week carry-forward of adopted state through extended checkpoint lookback

### DIFF
--- a/execution/engine/main.py
+++ b/execution/engine/main.py
@@ -633,16 +633,43 @@ class Engine:
                 await self._enter_disconnected(result, exc)
                 return
 
-        lookback_start = datetime.now(timezone.utc) - recovery_mod.DEFAULT_LOOKBACK
+        narrow_lookback_start = (
+            datetime.now(timezone.utc) - recovery_mod.DEFAULT_LOOKBACK
+        )
+        ext_lookback_start = (
+            datetime.now(timezone.utc)
+            - recovery_mod.EXTENDED_CHECKPOINT_LOOKBACK
+        )
         try:
             broker_positions = await self.connector.get_positions()
             broker_open_orders = await self.connector.get_open_orders()
-            broker_status = await self.connector.get_order_status_history(lookback_start)
+            # broker_status uses the narrow window: order-status history
+            # is recent broker activity, not a state checkpoint, and
+            # widening it would conflict with the existing
+            # reconciliation contract for terminal-state classification.
+            broker_status = await self.connector.get_order_status_history(
+                narrow_lookback_start
+            )
         except (AuthRequiredError, DisconnectedError) as exc:
             await self._enter_disconnected(result, exc, auth=isinstance(exc, AuthRequiredError))
             return
 
-        journal_tail = _read_recent_journal(self.journal, lookback_start)
+        narrow_journal_tail = _read_recent_journal(
+            self.journal, narrow_lookback_start
+        )
+        # Q42 +1 week carry-forward fix: prepend state-checkpoint
+        # events from the extended window so multi-day engine-off gaps
+        # don't re-flag previously-adopted positions / orphan STOPs as
+        # phantoms. Older events first, narrow tail second -- recovery
+        # replay walks forward and snapshot-resets per_ticker on each
+        # `engine_recovered`, so the most recent in the combined
+        # sequence wins.
+        extended_checkpoints = _read_extended_checkpoints(
+            self.journal,
+            ext_since=ext_lookback_start,
+            narrow_since=narrow_lookback_start,
+        )
+        journal_tail = extended_checkpoints + narrow_journal_tail
 
         # Codex round-3 P2: the EngineConfig-configurable override env
         # name must actually be consulted by reconcile(); otherwise a
@@ -2214,6 +2241,81 @@ def _read_recent_journal(
             LOG.warning("journal read_all(%s) raised: %s", when, exc)
     since_iso = since.isoformat()
     return [r for r in out if str(r.get("ts", "")) >= since_iso]
+
+
+def _read_extended_checkpoints(
+    journal: JournalWriter,
+    *,
+    ext_since: datetime,
+    narrow_since: datetime,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Read state-checkpoint events from [ext_since, narrow_since).
+
+    Q42 +1 week persistence FAIL (2026-05-03) carry-forward fix: a
+    multi-day engine-off gap leaves journal_tail empty under the 48h
+    DEFAULT_LOOKBACK, so the replay logic in
+    `recovery._positions_from_journal` and
+    `recovery._adopted_orphan_perm_ids` has nothing to seed from --
+    previously-adopted SPY positions and orphan STOPs re-flag as
+    phantoms.
+
+    This helper extends ONLY the lookup window for the event types in
+    `recovery.EXTENDED_CHECKPOINT_EVENT_TYPES`. Recovery's replay logic
+    is unchanged. Returns events in oldest-to-newest order so the
+    snapshot-reset semantics in `_positions_from_journal` apply
+    correctly (most recent `engine_recovered` wins).
+
+    Bounded by `recovery.EXTENDED_CHECKPOINT_LOOKBACK` (30 days).
+    File-system errors per day are logged-and-skipped, mirroring the
+    `_read_recent_journal` pattern -- a missing day file just means no
+    checkpoint that day, not a recovery failure.
+
+    `narrow_since` is the boundary that `_read_recent_journal` already
+    covers; events with `ts >= narrow_since` are filtered out here so
+    the caller can append the result to the narrow tail without
+    duplication.
+
+    `now` is injectable for tests; production passes the default
+    (`datetime.now(timezone.utc)`).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if ext_since >= narrow_since:
+        # Defensive: caller misconfigured the window. Return empty so
+        # behavior degrades to the current 48h-only lookup.
+        return []
+    out: list[dict[str, Any]] = []
+    days_back_ext = (now.date() - ext_since.date()).days
+    days_back_narrow = (now.date() - narrow_since.date()).days
+    # Walk day files from (narrow_since, ext_since] inclusive on the
+    # ext side; +1 because day_offset == days_back_narrow is already
+    # covered by `_read_recent_journal`.
+    for day_offset in range(days_back_narrow + 1, days_back_ext + 1):
+        when = now - timedelta(days=day_offset)
+        try:
+            day_records = journal.read_all(when)
+        except Exception as exc:  # pragma: no cover - shouldn't raise
+            LOG.warning(
+                "extended-checkpoint read_all(%s) raised: %s", when, exc
+            )
+            continue
+        for rec in day_records:
+            if (
+                rec.get("event_type")
+                not in recovery_mod.EXTENDED_CHECKPOINT_EVENT_TYPES
+            ):
+                continue
+            ts = str(rec.get("ts", ""))
+            if not ts:
+                continue
+            if ts < ext_since.isoformat():
+                continue
+            if ts >= narrow_since.isoformat():
+                continue  # already covered by narrow tail
+            out.append(rec)
+    out.sort(key=lambda r: str(r.get("ts", "")))
+    return out
 
 
 def _validate_journal_view(journal_view: dict[str, Any]) -> dict[str, Any] | None:

--- a/execution/engine/recovery.py
+++ b/execution/engine/recovery.py
@@ -87,6 +87,29 @@ ADOPT_ORPHAN_STOP_ENV = "K2BI_ADOPT_ORPHAN_STOP"
 # calendar day covers overnight crashes; longer outages trip the
 # weekly_cap breaker first anyway.
 DEFAULT_LOOKBACK = timedelta(hours=48)
+# Q42 +1 week persistence FAIL (2026-05-03) carry-forward fix:
+# state-checkpoint events MUST survive multi-day engine-off gaps so a
+# cold-start after >48h doesn't re-flag previously-adopted positions
+# / orphan STOPs as phantoms. 30 days covers any plausible operator-
+# attended outage window without unbounded scan growth (each day file
+# is small KB-scale; checkpoint events are sparse). Recovery REPLAY
+# semantics are unchanged -- the existing _positions_from_journal
+# snapshot-reset and _adopted_orphan_perm_ids extraction handle older
+# events correctly once they are present in journal_tail. Only the
+# LOOKUP WINDOW for the two checkpoint event types widens. See
+# K2Bi-Vault/wiki/planning/q42-carryforward-fix-kickoff.md.
+EXTENDED_CHECKPOINT_LOOKBACK = timedelta(days=30)
+# Event types whose payload represents a state checkpoint that must
+# survive multi-day engine-off gaps. Limited to these two because they
+# are the only journal events that encode broker-side state the
+# architect has already adopted: engine_recovered.adopted_positions
+# (post-recovery snapshot) and orphan_stop_adopted (per-permId
+# adoption). Other events (order_filled, recovery_reconciled) are
+# intermediate transitions whose effect is already absorbed by
+# engine_recovered's snapshot-reset semantics on the next cold start.
+EXTENDED_CHECKPOINT_EVENT_TYPES: frozenset[str] = frozenset(
+    {"engine_recovered", "orphan_stop_adopted"}
+)
 
 
 @dataclass(frozen=True)
@@ -149,11 +172,14 @@ def _adopted_orphan_perm_ids(records: Iterable[dict[str, Any]]) -> set[str]:
     so they collide cleanly with the `f"perm:{...}"` namespace used
     throughout reconcile().
 
-    NOTE: bounded by journal_tail's lookback window (currently 48h via
-    DEFAULT_LOOKBACK). Long-tail carry-forward via engine_recovered
-    checkpoint is Phase 4+ work; in practice the VPS engine restarts
-    continuously so adopted permIds stay in tail. See DEVLOG Q42 for
-    the long-tail caveat and Phase 4+ home.
+    NOTE: bounded by journal_tail's lookback window. The Q42 +1 week
+    carry-forward fix (2026-05-03) extends the lookup window via
+    `_read_extended_checkpoints` for these events specifically, so
+    adoptions survive multi-day engine-off gaps. The recognition is
+    GATED on the underlying position still being held at the broker
+    -- see `_adopted_orphan_perm_id_to_ticker` and the call site in
+    `reconcile()` -- so a stale adoption whose position has since
+    been closed does NOT suppress phantom_open_order detection.
     """
     out: set[str] = set()
     for rec in records:
@@ -163,6 +189,42 @@ def _adopted_orphan_perm_ids(records: Iterable[dict[str, Any]]) -> set[str]:
         perm = payload.get("permId")
         if perm is not None:
             out.add(str(perm))
+    return out
+
+
+def _adopted_orphan_perm_id_to_ticker(
+    records: Iterable[dict[str, Any]],
+) -> dict[str, str]:
+    """Map adopted-orphan permId -> ticker from orphan_stop_adopted events.
+
+    Q42 +1 week carry-forward review (2026-05-03, Kimi+Codex
+    cross-mode): the original Q42 recognition unconditionally
+    suppressed `phantom_open_order` for any permId in
+    `_adopted_orphan_perm_ids`. With the carry-forward fix extending
+    the lookup to 30 days, a stale adoption could mask a genuinely-
+    orphaned STOP whose underlying position has been closed in the
+    interim. The reconcile() call site uses this mapping to gate the
+    suppression: an adopted permId is only honored when the broker
+    still holds a position in the order's ticker.
+
+    Same fix tightens the existing narrow-window path too -- the gap
+    was always present, the carry-forward just widened the time
+    window over which it could manifest.
+
+    Returns dict[permId_str -> ticker]. Multiple records for the same
+    permId would be unusual (operator should adopt at most once per
+    orphan), but if present the LATEST event's ticker wins via the
+    natural dict-overwrite semantics during forward replay.
+    """
+    out: dict[str, str] = {}
+    for rec in records:
+        if rec.get("event_type") != "orphan_stop_adopted":
+            continue
+        payload = rec.get("payload") or {}
+        perm = payload.get("permId")
+        ticker = payload.get("ticker")
+        if perm is not None and ticker:
+            out[str(perm)] = str(ticker)
     return out
 
 
@@ -295,9 +357,25 @@ def reconcile(
     # Q42: orphan_stop_adopted events from prior recovery passes pre-mark
     # their permIds as known so the Phase B.1 orphan loop skips them.
     # Same recognition mechanism Phase A's perm/oid matching uses.
-    # Bounded by journal_tail's 48h lookback; see _adopted_orphan_perm_ids
-    # docstring for the long-tail caveat.
+    # Q42 +1 week carry-forward (2026-05-03) extends the lookup window
+    # via `_read_extended_checkpoints` so multi-day engine-off gaps
+    # don't re-flag adopted orphans as phantoms. Capital-path safety
+    # gate per cross-mode adversarial review (Kimi + Codex 2026-05-03):
+    # an adopted permId only suppresses phantom_open_order when the
+    # broker STILL HOLDS a position in the order's ticker. A stale
+    # adoption whose underlying position has been closed must fall
+    # through to phantom detection -- the orphan STOP would otherwise
+    # be live at the broker without an associated long position to
+    # protect, and engine state cannot reason about it safely.
+    adopted_perm_to_ticker = _adopted_orphan_perm_id_to_ticker(journal_tail)
+    broker_position_tickers = {p.ticker for p in broker_positions}
     for adopted_perm in _adopted_orphan_perm_ids(journal_tail):
+        ticker = adopted_perm_to_ticker.get(str(adopted_perm))
+        if ticker is not None and ticker not in broker_position_tickers:
+            # Stale orphan adoption: ticker no longer at broker.
+            # Skip the carry-forward; phantom_open_order will fire
+            # for the live STOP order and surface the divergence.
+            continue
         seen_broker_ids.add(f"perm:{adopted_perm}")
     # Per-ticker (signed_qty_delta, last_broker_avg_fill_price).
     # Positive qty means the pending was a buy that filled, growing

--- a/tests/test_engine_recovery_extended_checkpoints.py
+++ b/tests/test_engine_recovery_extended_checkpoints.py
@@ -1,0 +1,704 @@
+"""Tests for the Q42 +1 week carry-forward fix.
+
+The +1 week persistence check on 2026-05-03 surfaced that a multi-day
+engine-off gap empties the 48h `journal_tail` and re-flags both
+previously-adopted positions (`phantom_position`) and previously-
+adopted orphan STOPs (`phantom_open_order`) as mismatches. This test
+file exercises the carry-forward fix:
+
+1. Pure-function tests (T1-T6) feed older `engine_recovered` and
+   `orphan_stop_adopted` records DIRECTLY into `recovery.reconcile()`
+   to verify recovery's existing replay logic correctly carries the
+   adoptions forward when those events are made available. This is
+   the core invariant -- the smallest safe fix only widens the lookup
+   window; it does NOT change recovery semantics, so recovery's
+   handling of the older records IS what the fix relies on.
+
+2. Helper tests (T7-T10) drive `_read_extended_checkpoints` against
+   real on-disk journal day-files (via `JournalWriter`) to verify the
+   lookup window expansion is correct: only the two checkpoint event
+   types are picked up, only within the extended bound, only outside
+   the narrow tail.
+
+T4 explicitly preserves the Q31/Q32 invariant: with neither extended
+checkpoints nor narrow events, a genuine fresh broker state still
+refuses to start.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from execution.connectors.types import (
+    BrokerOpenOrder,
+    BrokerPosition,
+)
+from execution.engine import recovery
+from execution.engine.main import _read_extended_checkpoints
+from execution.journal.writer import JournalWriter
+
+
+NOW = datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc)
+
+
+def _engine_recovered_record(
+    *,
+    ts: datetime,
+    adopted_positions: list[dict],
+    expected_stop_children: list[dict] | None = None,
+) -> dict:
+    """Build a synthetic engine_recovered journal record."""
+    return {
+        "ts": ts.isoformat(),
+        "schema_version": 2,
+        "event_type": "engine_recovered",
+        "trade_id": None,
+        "journal_entry_id": "J-recovered",
+        "strategy": None,
+        "git_sha": "abc",
+        "payload": {
+            "status": "mismatch_override",
+            "reconciled_event_count": 1,
+            "adopted_positions": adopted_positions,
+            "expected_stop_children": expected_stop_children or [],
+        },
+    }
+
+
+def _orphan_stop_adopted_record(
+    *,
+    ts: datetime,
+    perm_id: int,
+    ticker: str = "SPY",
+    qty: int = 2,
+    stop_price: str = "697.13",
+    justification: str = "Phase-3.6-Day-1-Portal-submitted",
+) -> dict:
+    """Build a synthetic orphan_stop_adopted journal record."""
+    return {
+        "ts": ts.isoformat(),
+        "schema_version": 2,
+        "event_type": "orphan_stop_adopted",
+        "trade_id": None,
+        "journal_entry_id": "J-adopted",
+        "strategy": None,
+        "git_sha": "abc",
+        "payload": {
+            "permId": perm_id,
+            "ticker": ticker,
+            "qty": qty,
+            "stop_price": stop_price,
+            "source": "operator-portal",
+            "adopted_at": ts.isoformat(),
+            "justification": justification,
+        },
+        "ticker": ticker,
+        "broker_order_id": "",
+        "broker_perm_id": str(perm_id),
+    }
+
+
+class CarryForwardReplayTests(unittest.TestCase):
+    """T1-T6: Pure-function tests proving recovery's existing replay
+    correctly handles older checkpoint records once they are present
+    in journal_tail. The carry-forward fix only widens the lookup
+    window; these tests verify the downstream contract."""
+
+    def test_T1_engine_recovered_carries_position_after_long_gap(self):
+        """T1: Empty narrow tail + engine_recovered from 7 days ago.
+
+        Broker holds the position the architect previously adopted.
+        recovery._positions_from_journal must seed implied_positions
+        from the older engine_recovered's adopted_positions, and
+        Phase B must NOT flag phantom_position.
+        """
+        seven_days_ago = NOW - timedelta(days=7)
+        journal_tail = [
+            _engine_recovered_record(
+                ts=seven_days_ago,
+                adopted_positions=[
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+            ),
+        ]
+        result = recovery.reconcile(
+            journal_tail=journal_tail,
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.72")
+                )
+            ],
+            broker_open_orders=[],
+            broker_order_status=[],
+            now=NOW,
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.CATCH_UP,
+            f"expected CATCH_UP, got {result.status} with mismatches "
+            f"{result.mismatch_reasons}",
+        )
+        for m in result.mismatch_reasons:
+            self.assertNotEqual(m.get("case"), "phantom_position")
+
+    def test_T2_orphan_stop_adopted_carries_after_long_gap(self):
+        """T2: Empty narrow tail + orphan_stop_adopted from 7 days ago.
+
+        Broker holds the orphan STOP the architect previously adopted.
+        recovery._adopted_orphan_perm_ids must extract the permId from
+        the older event, and Phase B.1 must NOT flag phantom_open_order
+        for that order.
+        """
+        seven_days_ago = NOW - timedelta(days=7)
+        journal_tail = [
+            # Engine_recovered to satisfy position adoption -- without
+            # it the SPY broker position would itself flag phantom.
+            # We're testing the orphan STOP path; position carry is T1.
+            _engine_recovered_record(
+                ts=seven_days_ago,
+                adopted_positions=[
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+            ),
+            _orphan_stop_adopted_record(
+                ts=seven_days_ago + timedelta(hours=1),
+                perm_id=1888063981,
+            ),
+        ]
+        result = recovery.reconcile(
+            journal_tail=journal_tail,
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.72")
+                )
+            ],
+            broker_open_orders=[
+                BrokerOpenOrder(
+                    broker_order_id="61226127",
+                    broker_perm_id="1888063981",
+                    ticker="SPY",
+                    side="sell",
+                    qty=2,
+                    filled_qty=0,
+                    limit_price=Decimal("0"),
+                    status="PreSubmitted",
+                    tif="GTC",
+                    aux_price=Decimal("697.13"),
+                    order_type="STP",
+                )
+            ],
+            broker_order_status=[],
+            now=NOW,
+        )
+        for m in result.mismatch_reasons:
+            self.assertNotEqual(m.get("case"), "phantom_open_order")
+
+    def test_T3_both_adoptions_carry_forward_clean_start(self):
+        """T3: Both events from days 7+6 -> engine starts clean.
+
+        This is the production scenario the +1 week persistence check
+        exposed. After the fix, both adoptions should be visible to
+        the replay and engine should reach CATCH_UP.
+        """
+        seven_days_ago = NOW - timedelta(days=7)
+        six_days_ago = NOW - timedelta(days=6)
+        journal_tail = [
+            _engine_recovered_record(
+                ts=seven_days_ago,
+                adopted_positions=[
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+            ),
+            _orphan_stop_adopted_record(
+                ts=six_days_ago,
+                perm_id=1888063981,
+            ),
+        ]
+        result = recovery.reconcile(
+            journal_tail=journal_tail,
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.72")
+                )
+            ],
+            broker_open_orders=[
+                BrokerOpenOrder(
+                    broker_order_id="61226127",
+                    broker_perm_id="1888063981",
+                    ticker="SPY",
+                    side="sell",
+                    qty=2,
+                    filled_qty=0,
+                    limit_price=Decimal("0"),
+                    status="PreSubmitted",
+                    tif="GTC",
+                    aux_price=Decimal("697.13"),
+                    order_type="STP",
+                )
+            ],
+            broker_order_status=[],
+            now=NOW,
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.CATCH_UP,
+            f"expected CATCH_UP, got {result.status} with mismatches "
+            f"{result.mismatch_reasons}",
+        )
+        self.assertEqual(result.mismatch_reasons, [])
+
+    def test_T4_no_checkpoints_still_refuses_start(self):
+        """T4: Empty journal_tail (genuinely fresh) + broker holds
+        unknown position -> MISMATCH_REFUSED.
+
+        Preserves the Q31/Q32 invariant: the carry-forward fix only
+        works when checkpoint events exist in the extended window. A
+        truly fresh state with no prior adoption MUST still refuse to
+        start so the architect explicitly engages
+        K2BI_ALLOW_RECOVERY_MISMATCH=1 and documents the override.
+        """
+        result = recovery.reconcile(
+            journal_tail=[],
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.72")
+                )
+            ],
+            broker_open_orders=[],
+            broker_order_status=[],
+            now=NOW,
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.MISMATCH_REFUSED,
+        )
+        cases = [m.get("case") for m in result.mismatch_reasons]
+        self.assertIn("phantom_position", cases)
+
+    def test_T5_multiple_engine_recovered_latest_wins(self):
+        """T5: Two engine_recovered events with different positions.
+
+        Snapshot-reset semantics in _positions_from_journal mean the
+        per_ticker map is wiped on each engine_recovered. The most
+        recent event in the replay sequence determines the seed.
+        """
+        ten_days_ago = NOW - timedelta(days=10)
+        five_days_ago = NOW - timedelta(days=5)
+        journal_tail = [
+            # Older record claims SPY 5 @ 700 -- if this leaked
+            # through, the broker's SPY 2 @ 707.72 would diff.
+            _engine_recovered_record(
+                ts=ten_days_ago,
+                adopted_positions=[
+                    {"ticker": "SPY", "qty": 5, "avg_price": "700.00"}
+                ],
+            ),
+            # Newer record correctly claims SPY 2 @ 707.72.
+            _engine_recovered_record(
+                ts=five_days_ago,
+                adopted_positions=[
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+            ),
+        ]
+        result = recovery.reconcile(
+            journal_tail=journal_tail,
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.72")
+                )
+            ],
+            broker_open_orders=[],
+            broker_order_status=[],
+            now=NOW,
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.CATCH_UP,
+            f"latest engine_recovered must override; got "
+            f"{result.status} with mismatches {result.mismatch_reasons}",
+        )
+
+    def test_T13_stale_orphan_with_closed_position_fires_phantom(self):
+        """T13: orphan_stop_adopted from extended window, but the
+        broker no longer holds any position in that ticker -- the
+        live STOP order is now genuinely orphaned and phantom_open_order
+        MUST fire.
+
+        Capital-path safety gate per cross-mode adversarial review
+        (Kimi + Codex 2026-05-03): the original Q42 unconditionally
+        suppressed phantom detection for any adopted permId. With the
+        carry-forward fix extending the lookup to 30 days, a stale
+        adoption whose underlying position has since been closed
+        could mask a dangling broker-side STOP. The position-aware
+        gate at the recognition step keeps this safety property even
+        when extended-window adoptions are present.
+        """
+        seven_days_ago = NOW - timedelta(days=7)
+        journal_tail = [
+            _orphan_stop_adopted_record(
+                ts=seven_days_ago,
+                perm_id=1888063981,
+                ticker="SPY",
+            ),
+        ]
+        result = recovery.reconcile(
+            journal_tail=journal_tail,
+            # Position closed -- broker holds NO SPY.
+            broker_positions=[],
+            # ...but the broker-side STOP for the OLD position is
+            # still live (a real-world bracket-child that wasn't
+            # cancelled when the parent fully closed externally).
+            broker_open_orders=[
+                BrokerOpenOrder(
+                    broker_order_id="61226127",
+                    broker_perm_id="1888063981",
+                    ticker="SPY",
+                    side="sell",
+                    qty=2,
+                    filled_qty=0,
+                    limit_price=Decimal("0"),
+                    status="PreSubmitted",
+                    tif="GTC",
+                    aux_price=Decimal("697.13"),
+                    order_type="STP",
+                )
+            ],
+            broker_order_status=[],
+            now=NOW,
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.MISMATCH_REFUSED,
+            f"stale orphan adoption with closed position must NOT "
+            f"suppress phantom_open_order; got {result.status} "
+            f"with mismatches {result.mismatch_reasons}",
+        )
+        cases = [m.get("case") for m in result.mismatch_reasons]
+        self.assertIn("phantom_open_order", cases)
+
+    def test_T14_orphan_with_held_position_carries_forward(self):
+        """T14: Companion to T13 -- when the position IS still held,
+        the orphan adoption gates open and phantom_open_order is
+        correctly suppressed.
+
+        Together with T13 this proves the position-aware gate gates
+        on the right axis: position-still-held passes; position-
+        closed fails closed.
+        """
+        seven_days_ago = NOW - timedelta(days=7)
+        journal_tail = [
+            _engine_recovered_record(
+                ts=seven_days_ago,
+                adopted_positions=[
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+            ),
+            _orphan_stop_adopted_record(
+                ts=seven_days_ago + timedelta(hours=1),
+                perm_id=1888063981,
+                ticker="SPY",
+            ),
+        ]
+        result = recovery.reconcile(
+            journal_tail=journal_tail,
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.72")
+                )
+            ],
+            broker_open_orders=[
+                BrokerOpenOrder(
+                    broker_order_id="61226127",
+                    broker_perm_id="1888063981",
+                    ticker="SPY",
+                    side="sell",
+                    qty=2,
+                    filled_qty=0,
+                    limit_price=Decimal("0"),
+                    status="PreSubmitted",
+                    tif="GTC",
+                    aux_price=Decimal("697.13"),
+                    order_type="STP",
+                )
+            ],
+            broker_order_status=[],
+            now=NOW,
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.CATCH_UP,
+            f"position-held + orphan-adoption must reach CATCH_UP; "
+            f"got {result.status} with mismatches {result.mismatch_reasons}",
+        )
+        for m in result.mismatch_reasons:
+            self.assertNotEqual(m.get("case"), "phantom_open_order")
+
+    def test_T6_phantom_when_broker_diverges_from_checkpoint(self):
+        """T6: Older engine_recovered claims SPY 2, broker shows SPY 5.
+
+        The carry-forward seeds implied_positions from the checkpoint,
+        but Phase B still runs the position-vs-broker diff. A genuine
+        divergence (broker holds different qty than the checkpoint
+        records) must surface as a mismatch -- the fix must NOT
+        suppress real divergence detection.
+        """
+        seven_days_ago = NOW - timedelta(days=7)
+        journal_tail = [
+            _engine_recovered_record(
+                ts=seven_days_ago,
+                adopted_positions=[
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+            ),
+        ]
+        result = recovery.reconcile(
+            journal_tail=journal_tail,
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=5, avg_price=Decimal("707.72")
+                )
+            ],
+            broker_open_orders=[],
+            broker_order_status=[],
+            now=NOW,
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.MISMATCH_REFUSED,
+            "broker qty divergence from checkpoint must surface mismatch",
+        )
+
+
+class ReadExtendedCheckpointsTests(unittest.TestCase):
+    """T7-T10: Helper tests for `_read_extended_checkpoints` against
+    real on-disk journal day-files."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmp.name)
+        self.journal = JournalWriter(base_dir=self.tmpdir, git_sha="abc")
+        # Fixed "now" for deterministic day-offset arithmetic.
+        self.now = datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, *, ts: datetime, event_type: str, payload: dict):
+        self.journal.append(event_type, payload, ts=ts)
+
+    def test_T7_helper_returns_only_checkpoint_event_types(self):
+        """T7: Helper must filter to engine_recovered + orphan_stop_adopted.
+
+        Other event types written in the same window MUST NOT appear
+        in the returned list.
+        """
+        five_days_ago = self.now - timedelta(days=5)
+        self._write(
+            ts=five_days_ago,
+            event_type="engine_recovered",
+            payload={
+                "status": "catch_up",
+                "reconciled_event_count": 0,
+                "adopted_positions": [
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+                "expected_stop_children": [],
+            },
+        )
+        self._write(
+            ts=five_days_ago + timedelta(minutes=1),
+            event_type="orphan_stop_adopted",
+            payload={
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": (
+                    five_days_ago + timedelta(minutes=1)
+                ).isoformat(),
+                "justification": "test",
+            },
+        )
+        # Noise events that must NOT appear in extended checkpoints.
+        self._write(
+            ts=five_days_ago + timedelta(minutes=2),
+            event_type="engine_started",
+            payload={
+                "pid": 999,
+                "tick_seconds": 30.0,
+                "recovery_status": "catch_up",
+                "reconciled_event_count": 0,
+                "mismatch_count": 0,
+                "strategies_loaded": [],
+                "strategies": [],
+                "resumed_awaiting": None,
+                "validator_config_hash": "hash",
+                "kill_file_present_at_startup": False,
+                "retired_dir": str(self.tmpdir),
+            },
+        )
+        self._write(
+            ts=five_days_ago + timedelta(minutes=3),
+            event_type="engine_stopped",
+            payload={
+                "reason": "test",
+                "terminal_state": "halted",
+            },
+        )
+
+        out = _read_extended_checkpoints(
+            self.journal,
+            ext_since=self.now - timedelta(days=30),
+            narrow_since=self.now - timedelta(days=2),
+            now=self.now,
+        )
+        types = [r["event_type"] for r in out]
+        self.assertEqual(
+            sorted(types),
+            ["engine_recovered", "orphan_stop_adopted"],
+            f"unexpected event types in helper output: {types}",
+        )
+
+    def test_T8_helper_excludes_events_within_narrow_window(self):
+        """T8: An event whose ts is within [narrow_since, now] must be
+        excluded -- it's covered by `_read_recent_journal` and would
+        double-count if returned here."""
+        one_day_ago = self.now - timedelta(days=1)
+        self._write(
+            ts=one_day_ago,
+            event_type="engine_recovered",
+            payload={
+                "status": "catch_up",
+                "reconciled_event_count": 0,
+                "adopted_positions": [],
+                "expected_stop_children": [],
+            },
+        )
+        out = _read_extended_checkpoints(
+            self.journal,
+            ext_since=self.now - timedelta(days=30),
+            narrow_since=self.now - timedelta(days=2),
+            now=self.now,
+        )
+        self.assertEqual(out, [])
+
+    def test_T9_helper_excludes_events_older_than_extended_window(self):
+        """T9: An event whose ts is older than `ext_since` must be
+        excluded -- the 30-day bound is an explicit policy choice."""
+        thirty_one_days_ago = self.now - timedelta(days=31)
+        self._write(
+            ts=thirty_one_days_ago,
+            event_type="engine_recovered",
+            payload={
+                "status": "catch_up",
+                "reconciled_event_count": 0,
+                "adopted_positions": [
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+                "expected_stop_children": [],
+            },
+        )
+        out = _read_extended_checkpoints(
+            self.journal,
+            ext_since=self.now - timedelta(days=30),
+            narrow_since=self.now - timedelta(days=2),
+            now=self.now,
+        )
+        self.assertEqual(out, [])
+
+    def test_T10_helper_returns_events_sorted_oldest_first(self):
+        """T10: Records returned must be sorted by ts ascending so the
+        recovery replay's snapshot-reset semantics apply correctly
+        (most recent engine_recovered wins)."""
+        # Write out-of-order: newer first, then older.
+        five_days_ago = self.now - timedelta(days=5)
+        ten_days_ago = self.now - timedelta(days=10)
+        self._write(
+            ts=five_days_ago,
+            event_type="engine_recovered",
+            payload={
+                "status": "catch_up",
+                "reconciled_event_count": 0,
+                "adopted_positions": [
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+                "expected_stop_children": [],
+            },
+        )
+        self._write(
+            ts=ten_days_ago,
+            event_type="engine_recovered",
+            payload={
+                "status": "catch_up",
+                "reconciled_event_count": 0,
+                "adopted_positions": [
+                    {"ticker": "SPY", "qty": 5, "avg_price": "700.00"}
+                ],
+                "expected_stop_children": [],
+            },
+        )
+        out = _read_extended_checkpoints(
+            self.journal,
+            ext_since=self.now - timedelta(days=30),
+            narrow_since=self.now - timedelta(days=2),
+            now=self.now,
+        )
+        self.assertEqual(len(out), 2)
+        self.assertLess(out[0]["ts"], out[1]["ts"])
+
+    def test_T11_helper_handles_missing_day_files(self):
+        """T11: Days with no journal file must not raise -- helper
+        treats them as "no checkpoint that day" and continues."""
+        # Only write one day file in the extended window; other days
+        # have no file at all (gap, mirroring the 2026-04-28..05-02
+        # production gap).
+        five_days_ago = self.now - timedelta(days=5)
+        self._write(
+            ts=five_days_ago,
+            event_type="engine_recovered",
+            payload={
+                "status": "catch_up",
+                "reconciled_event_count": 0,
+                "adopted_positions": [
+                    {"ticker": "SPY", "qty": 2, "avg_price": "707.72"}
+                ],
+                "expected_stop_children": [],
+            },
+        )
+        out = _read_extended_checkpoints(
+            self.journal,
+            ext_since=self.now - timedelta(days=30),
+            narrow_since=self.now - timedelta(days=2),
+            now=self.now,
+        )
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["event_type"], "engine_recovered")
+
+    def test_T12_helper_returns_empty_when_window_inverted(self):
+        """T12: Defensive check -- ext_since >= narrow_since should
+        return an empty list, not crash."""
+        out = _read_extended_checkpoints(
+            self.journal,
+            ext_since=self.now - timedelta(days=2),
+            narrow_since=self.now - timedelta(days=2),
+            now=self.now,
+        )
+        self.assertEqual(out, [])
+
+        out = _read_extended_checkpoints(
+            self.journal,
+            ext_since=self.now - timedelta(days=1),
+            narrow_since=self.now - timedelta(days=2),
+            now=self.now,
+        )
+        self.assertEqual(out, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the **Q42 +1 week persistence FAIL** surfaced 2026-05-03 13:00 UTC. A 6-day engine-off gap left `journal_tail` empty under `DEFAULT_LOOKBACK` (48h), so both the adopted SPY position (`phantom_position`) and the adopted orphan STOP `permId 1888063981` (`phantom_open_order`) re-flagged on the forced cold start. Architect ruling D3 from the original Q42 ship explicitly deferred this exact failure mode to "Phase 4+ work" — now elevated to **Phase 3.10 burn-in gate**.

**Smallest-safe-fix:** widen the LOOKUP WINDOW only for the two state-checkpoint event types. Recovery's existing replay logic handles older records correctly once they are present in `journal_tail`. Q31/Q32 invariants stay live to catch genuine unknown broker state.

- Add `EXTENDED_CHECKPOINT_LOOKBACK = 30 days` + `EXTENDED_CHECKPOINT_EVENT_TYPES` frozenset (`engine_recovered`, `orphan_stop_adopted`)
- New `_read_extended_checkpoints()` helper in `main.py` walks day files in `(narrow_since, ext_since]`, filters to checkpoint event types, returns events sorted oldest-first; wired into `_run_recovery` so `journal_tail = extended_checkpoints + narrow_tail`
- **Position-aware gate** on `orphan_stop_adopted` carry-forward in `reconcile()`: an adopted permId only suppresses `phantom_open_order` when broker still holds a position in the order's ticker. Closes the Kimi cross-mode review CRITICAL finding (stale adoption whose underlying position has been closed must NOT mask a dangling broker-side STOP). Same gate also tightens existing narrow-window behavior — gap was always present, carry-forward just widened the time window.

## Tests

14 new tests in `tests/test_engine_recovery_extended_checkpoints.py`:

| ID | Scenario |
|---|---|
| T1 | engine_recovered carries position after long gap |
| T2 | orphan_stop_adopted carries after long gap |
| T3 | both adoptions carry forward → CATCH_UP |
| T4 | no checkpoints + unknown broker state still refuses (Q31/Q32 invariant) |
| T5 | multiple engine_recovered → latest wins (snapshot reset) |
| T6 | broker diverges from checkpoint → MISMATCH still fires |
| T7 | helper filters to checkpoint event types only |
| T8 | helper excludes events within narrow window (no double-count) |
| T9 | helper excludes events older than `EXTENDED_CHECKPOINT_LOOKBACK` |
| T10 | helper sorts oldest-first |
| T11 | helper handles missing day files |
| T12 | helper defensive on inverted windows |
| T13 | stale orphan + closed position → `phantom_open_order` fires |
| T14 | orphan + held position → carry-forward works |

**169 tests pass** across recovery + engine_main + new file; **0 regressions**. Pre-existing failure in `test_invest_alert_integration.py::MixedJournalTests::test_mixed_events_produce_correct_tier_split` confirmed on `main`, unrelated to this branch.

## Review trail

Cross-mode adversarial discipline applied. Two independent Kimi reviews flagged the stale-orphan-stop suppression risk as CRITICAL/HIGH and converged on the position-aware gate recommendation. Codex review captured the fix in its mid-investigation note before its turn wedged ("verifying" phase, 21 min idle); we did not block on the verdict given Kimi cross-coverage and operator explicit `don't wait for codex`.

## Architect-side artifacts (K2Bi-Vault, separate sync via Syncthing)

- `wiki/planning/q42-carryforward-fix-kickoff.md` (spec / kickoff doc)
- `wiki/planning/q42-orphan-stop-adoption-kickoff.md` (parent ship, status: `shipped-with-known-decay-gap` pending this PR's land + production validation)
- `wiki/planning/upcoming-sessions.md` finding (x) +1week verdict closure
- `wiki/planning/milestones.md` Q42 row
- `wiki/planning/index.md` Resume Card top banner

## Architect-side memory (K2B-Vault)

- `System/memory/self_improve_learnings.md` L-2026-05-03-001
- `System/memory/self_improve_requests.md` REQ-2026-05-03-001
- `wiki/context/policy-ledger.jsonl` guard `scope=engine-recovery-cold-start`

## Test plan

- [x] All 14 new tests pass
- [x] All 167 existing recovery + engine_main tests pass (no regressions)
- [x] Cross-mode adversarial review (2x Kimi)
- [x] Position-aware gate fix verified by T13 + T14 (stale + closed → phantom fires; held → carry-forward works)
- [ ] **Production validation (post-merge):**
  ```
  ssh hostinger "sudo rm /etc/systemd/system/k2bi-engine.service.d/override.conf && \
    sudo systemctl daemon-reload && \
    sudo systemctl restart k2bi-engine.service"
  ```
  Then verify engine cold-starts clean (`engine_started` + `engine_recovered` journaled, no `recovery_state_mismatch` override path hit). On PASS, flip Q42 status from `shipped-with-known-decay-gap` to `shipped` and unblock Phase 3.10 burn-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)