### PR TITLE
Add orchestrator safety gate adapters

### DIFF
--- a/.code-reviews/orchestrator-adapters-round-1-response.md
+++ b/.code-reviews/orchestrator-adapters-round-1-response.md
@@ -1,0 +1,78 @@
+# Orchestrator Adapters Review Round 1 Response
+
+Review artifact: `.code-reviews/2026-06-04T14-19-39Z_f5fa3b.log`
+
+Reviewer metadata: `primary_used=minimax`, `fallback_used=false`
+
+Verdict: `NEEDS-ATTENTION`
+
+## Finding Disposition
+
+### 1. HIGH rollback restoration uses same write primitive without integrity check
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: `run_full_ship` could leave `status: approved` on disk after a failed post-helper gate if rollback failed.
+- action: added pre-mutation SHA-256 capture, verified rollback bytes, staged-reset attempt, and distinct rollback failure error.
+- verification: `test_failed_diff_review_restores_original_bytes_and_does_not_commit`
+
+### 2. HIGH review verdict extraction is substring-based
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: a log containing the word `APPROVE` outside a verdict header could previously return `APPROVE`.
+- action: replaced broad substring scan with strict `# ... review -- APPROVE|NEEDS-ATTENTION` header parsing plus optional JSON verdict line parsing.
+- verification: `test_review_verdict_requires_strict_header`
+
+### 3. HIGH review script JSON envelope parsed without schema validation
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: missing `job_id` or bad `log_path` could produce confusing or unsafe review-state reads.
+- action: added envelope schema checks for job id, repo-relative log path containment, log existence, state-file existence, `primary_used`, and `fallback_used`.
+- verification: `test_review_envelope_missing_job_id_refuses`
+
+### 4. MEDIUM approval token is replayable
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: static `APPROVE_STRATEGY:<slug>` did not bind Keith's approval to the reviewed file bytes.
+- action: approval token now requires `APPROVE_STRATEGY:<slug>:<strategy_sha256>` and refuses when the file changes after capture.
+- verification: `test_replayed_approval_token_refuses_after_file_content_changes`
+
+### 5. MEDIUM git commit lacks signature verification or branch protection check
+
+- reproduce: partially
+- material-to-live-risk: no for GPG, yes for unintended staged content
+- disposition: partial
+- evidence: K2Bi repo rules require exact staging and no `--no-verify`; they do not currently require signed commits or branch-protection checks inside helper functions.
+- action: accepted adjacent safety by un-staging the intended file on failed post-stage gates and keeping commit scoped to the one strategy path. GPG and branch-protection enforcement are deferred until K2Bi declares them as hard repo policy.
+- verification: full pytest plus review-disposition record
+
+### 6. MEDIUM run_git_command lacks timeout and command validation
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: a default git runner without timeout can hang the orchestrator, and a non-git command should not be accepted by the default path.
+- action: added `GIT_TIMEOUT_S=30`, restricted default runner to `git` commands, and allowed only the subcommands the adapter uses or inspects.
+- verification: `test_run_git_command_rejects_non_git_command`
+
+### 7. MEDIUM repo root fallback is heuristic
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: full ship requires a real git checkout; falling back to `parents[2]` could target the wrong tree.
+- action: `_repo_root_for` now fails closed with `OrchestratorGateError` when `git rev-parse --show-toplevel` fails or returns empty output.
+- verification: `test_repo_root_probe_fails_closed_outside_git`
+
+## Post-Fix Verification
+
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py -q` -> 15 passed
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py tests/test_invest_thesis.py tests/test_invest_coach.py tests/test_invest_ship_strategy.py -q` -> 257 passed
+- `python3 -m pytest tests/ -q` -> 1783 passed, 1 skipped, 53 subtests passed, 2 dependency warnings

--- a/.code-reviews/orchestrator-adapters-round-2-response.md
+++ b/.code-reviews/orchestrator-adapters-round-2-response.md
@@ -1,0 +1,87 @@
+# Orchestrator Adapters Review Round 2 Response
+
+Review artifact: `.code-reviews/2026-06-04T14-29-01Z_8c0ec8.log`
+
+Reviewer metadata: `primary_used=minimax`, `fallback_used=false`
+
+Verdict: `NEEDS-ATTENTION`
+
+## Finding Disposition
+
+### 1. CRITICAL git restore failure silently swallowed during rollback
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: failed `git restore --staged` could leave approved content in the index while working-tree bytes were restored.
+- action: rollback now preserves the staged-restore exception and raises a distinct `OrchestratorGateError` after restoring the working tree, instead of swallowing the index failure.
+- verification: `test_restore_staged_failure_is_not_swallowed`
+
+### 2. HIGH review script execution has no timeout
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: `run_review_with_script` used `subprocess.run` without timeout.
+- action: added `REVIEW_TIMEOUT_S=420` and explicit `TimeoutExpired` handling.
+- verification: `test_review_script_timeout_refuses`
+
+### 3. HIGH rollback verification TOCTOU race
+
+- reproduce: partially
+- material-to-live-risk: yes
+- disposition: partial
+- evidence: verification after `atomic_write_bytes` cannot be made fully race-free without changing the shared write primitive, but the adapter can reduce the post-write verification window.
+- action: changed verification to compute the digest through a freshly opened file descriptor immediately after the atomic replace and improved rollback failure messaging.
+- verification: `test_failed_diff_review_restores_original_bytes_and_does_not_commit`
+
+### 4. HIGH commit message log path injection
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: review result fields were embedded directly into commit message metadata.
+- action: added commit-field sanitization that rejects empty values, newlines, control characters, and trailer-like values before building the message.
+- verification: `test_commit_message_rejects_log_path_with_newline`
+
+### 5. HIGH commit not scoped to exactly one file
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: plain `git commit -m` can include unrelated pre-staged content.
+- action: commit now uses `git commit --only <strategy path> -m <message>` after staging the intended strategy path.
+- verification: `test_success_runs_plan_review_diff_review_helper_and_commit`
+
+### 6. MEDIUM `_repo_relative` falls back to absolute path
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: an escaped path could be passed into git operations as an absolute path.
+- action: `_repo_relative` now fails closed with `OrchestratorGateError` when a path cannot be resolved under the repo root.
+- verification: `test_repo_relative_refuses_path_outside_repo`
+
+### 7. MEDIUM review envelope lacks request correlation
+
+- reproduce: partially
+- material-to-live-risk: yes
+- disposition: partial
+- evidence: the wrapper state file already records `scope`, `files`, `plan`, and `focus`, but the adapter did not check those fields in Round 2.
+- action: deferred nonce-level correlation because `scripts/review.sh` does not currently expose an echo nonce. Existing hardening now requires a fresh valid job id, contained log path, state file, `primary_used`, and `fallback_used`. A future review-runner change can add nonce echoing centrally.
+- verification: Round 1 envelope tests still pass.
+
+### 8. MEDIUM approve handler mutates before diff review
+
+- reproduce: no as stated
+- material-to-live-risk: no
+- disposition: rejected
+- evidence: this ordering matches `/invest-ship --approve-strategy`: Step A/D mutates status to approved, then Checkpoint 2 reviews the resulting uncommitted diff against HEAD. `git diff HEAD` includes unstaged working-tree changes, so staging is not required for review visibility.
+- action: no code change.
+- verification: existing `run_full_ship` success path records review order as `["plan", "diff"]`, with diff review after helper mutation and before commit.
+
+## Post-Fix Verification
+
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py -q` -> 19 passed
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py tests/test_invest_thesis.py tests/test_invest_coach.py tests/test_invest_ship_strategy.py -q` -> 261 passed
+- `python3 -m pytest tests/ -q` -> 1787 passed, 1 skipped, 53 subtests passed, 2 dependency warnings

--- a/.code-reviews/orchestrator-adapters-round-3-response.md
+++ b/.code-reviews/orchestrator-adapters-round-3-response.md
@@ -1,0 +1,79 @@
+# Orchestrator Adapters Review Round 3 Response
+
+Review artifact: `.code-reviews/2026-06-04T14-38-40Z_2d7905.log`
+
+Reviewer metadata: `primary_used=minimax`, `fallback_used=false`
+
+Verdict: `NEEDS-ATTENTION`
+
+## Finding Disposition
+
+### 1. HIGH rollback verification retains TOCTOU race on shared write primitive
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: `run_full_ship` could interleave with another process while reading original bytes, mutating status, and rolling back.
+- action: added an exclusive nonblocking per-strategy `flock` around the full read, review, mutation, staging, commit, and rollback sequence.
+- verification: `test_existing_strategy_lock_refuses_concurrent_ship`
+
+### 2. HIGH concurrent `run_full_ship` calls can corrupt rollback state
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: two callers on the same strategy could both capture stale original bytes and one rollback could undo the other's change.
+- action: same per-strategy lock now fails closed before review or mutation when another ship is active for that strategy.
+- verification: `test_existing_strategy_lock_refuses_concurrent_ship`
+
+### 3. HIGH nested exception in rollback can suppress original failure cause
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: rollback failure handling could surface only the restore failure path and lose context about the original ship failure.
+- action: rollback now records staged-restore and working-tree-restore outcomes separately, then raises one `OrchestratorGateError` containing the original ship error and every rollback error observed.
+- verification: `test_restore_staged_failure_is_not_swallowed`
+
+### 4. MEDIUM approval token binds to pre-mutation hash, enabling replay after external revert
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: partial
+- evidence: the token previously bound only slug and pre-approval file hash. A fully nonce-backed token needs orchestrator-side nonce issuance that this repo does not own.
+- action: token now binds slug, pre-approval file hash, and exact `approved_at` timestamp, closing stale token reuse across changed file content and timestamp mismatch while keeping the adapter dependency-free.
+- verification: `test_replayed_approval_token_refuses_after_file_content_changes`
+
+### 5. MEDIUM no observability hooks for production failure reconstruction
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: partial
+- evidence: successful callable ship results did not expose structured gate state to the external orchestrator.
+- action: `FullShipResult` now carries structured in-memory events for ship start, review completions, helper completion, git staging, commit success, and rollback attempts. Persistent logging is left to the external orchestrator because this adapter has no configured log sink.
+- verification: `test_success_runs_plan_review_diff_review_helper_and_commit`
+
+### 6. MEDIUM `_run_git_checked` allows None result to pass silently
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: an injected git runner returning `None` could be treated as success.
+- action: `_run_git_checked` now requires a `CommandResult` and fails closed otherwise.
+- verification: `test_run_git_checked_requires_command_result`
+
+### 7. MEDIUM `run_review_with_script` trusts `review.sh` stdout without stderr validation
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: a zero-exit review wrapper could emit a JSON envelope on stdout while writing unexpected warnings to stderr.
+- action: `run_review_with_script` now rejects non-empty stderr even when exit code is 0, before trusting the envelope.
+- verification: `test_review_script_nonempty_stderr_refuses`
+
+## Post-Fix Verification
+
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py -q` -> 22 passed
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py tests/test_invest_thesis.py tests/test_invest_coach.py tests/test_invest_ship_strategy.py -q` -> 264 passed
+- `python3 -m pytest tests/ -q` -> 1790 passed, 1 skipped, 53 subtests passed, 2 dependency warnings
+- `python3 scripts/lib/deploy_config.py preflight` -> passed

--- a/.code-reviews/orchestrator-adapters-round-4-response.md
+++ b/.code-reviews/orchestrator-adapters-round-4-response.md
@@ -1,0 +1,43 @@
+# Orchestrator Adapters Review Round 4 Response
+
+Review artifact: `.code-reviews/2026-06-04T15-13-20Z_758a13.log`
+
+Reviewer metadata: `primary_used=minimax`, `fallback_used=false`
+
+Verdict: `NEEDS-ATTENTION`
+
+## Finding Disposition
+
+### 1. HIGH advisory flock does not protect concurrent ships across working copies or containers
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: the local per-strategy flock only coordinates callers that share the same checkout and lockfile path.
+- action: `FullShipApproval` now requires `ship_lease_id` from the external orchestrator's mutual-exclusion layer, and the final approval token binds slug, pre-approval file hash, `approved_at`, and `ship_lease_id`. The `run_full_ship` docstring now states the local flock is same-checkout only and distributed callers must provide their own lease.
+- verification: `test_missing_external_ship_lease_fails_before_review`
+
+### 2. HIGH review focus string is passed to shell script without validation or escaping
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: `request.focus` reached `scripts/review.sh` without a length or control-character gate.
+- action: added `_safe_review_focus`, which rejects non-strings, strings over 2000 characters, CR/LF/NUL/control characters, and path-traversal text before spawning the review wrapper.
+- verification: `test_review_script_rejects_unsafe_focus_before_spawn`
+
+### 3. MEDIUM rollback working-tree restore uses same atomic write primitive without verifying file system identity
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: a symlink or hardlinked strategy path could make rollback target identity ambiguous.
+- action: `run_full_ship` now refuses symlink, special-file, or hardlinked strategy paths before reading or mutating them, and rollback rechecks the target before restoring original bytes.
+- verification: `test_full_ship_refuses_symlink_strategy_before_review`, `test_full_ship_refuses_hardlinked_strategy_before_review`
+
+## Post-Fix Verification
+
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py -q` -> 26 passed
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py tests/test_invest_thesis.py tests/test_invest_coach.py tests/test_invest_ship_strategy.py -q` -> 268 passed
+- `python3 -m pytest tests/ -q` -> 1794 passed, 1 skipped, 53 subtests passed, 2 dependency warnings
+- `python3 scripts/lib/deploy_config.py preflight` -> passed

--- a/.code-reviews/orchestrator-adapters-round-5-response.md
+++ b/.code-reviews/orchestrator-adapters-round-5-response.md
@@ -1,0 +1,88 @@
+# Orchestrator Adapters Review Round 5 Response
+
+Review artifact: `.code-reviews/2026-06-04T15-21-59Z_cf1568.log`
+
+Reviewer metadata: `primary_used=minimax`, `fallback_used=false`
+
+Verdict: `NEEDS-ATTENTION`
+
+## Finding Disposition
+
+### 1. CRITICAL rollback does not verify index restoration before working-tree restore
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: restoring working-tree bytes while the index still contains approved content creates a split-brain git state.
+- action: rollback now attempts `git restore --staged`, falls back to `git reset HEAD -- <path>`, and refuses to restore working-tree bytes unless `git diff --cached --quiet -- <path>` proves the index is clean.
+- verification: `test_dirty_index_blocks_working_tree_restore_after_commit_failure`
+
+### 2. HIGH advisory flock is lost on unclean shutdown
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: process death releases the advisory lock but can leave approved uncommitted state behind.
+- action: lock acquisition now writes a pending ship marker after taking the lock, clears it only on normal context exit, and refuses future ships if a pending marker remains. The adapter still requires the external `ship_lease_id` for cross-checkout exclusion.
+- verification: `test_stale_pending_strategy_lock_marker_refuses`
+
+### 3. HIGH approval token binds to second-granularity timestamp
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: second-only timestamps leave a same-second replay window.
+- action: `approved_at` must parse as ISO-8601 and include nonzero microseconds. The token still binds slug, file hash, timestamp, and ship lease.
+- verification: `test_approval_timestamp_requires_microseconds`
+
+### 4. HIGH `git commit --only` failure modes and `--no-verify`
+
+- reproduce: partially
+- material-to-live-risk: yes
+- disposition: partial, reject `--no-verify`
+- evidence: commit failure and index rollback risk are real and are now covered by stricter rollback checks. Adding `--no-verify` conflicts with K2Bi's safety architecture because pre-commit and commit-msg hooks enforce strategy transition and content immutability rules.
+- action: kept hooks enabled, kept `git commit --only <path>`, added index-clean verification before working-tree restore, and left broader real-git conflict/submodule coverage as future hardening outside this adapter pass.
+- verification: `test_dirty_index_blocks_working_tree_restore_after_commit_failure`, existing commit-order tests
+
+### 5. HIGH `_extract_review_verdict` returns generic `UNKNOWN`
+
+- reproduce: yes
+- material-to-live-risk: medium
+- disposition: accepted
+- evidence: infra failures and parse failures were collapsed into one ambiguous verdict value.
+- action: missing logs now return `LOG_MISSING`; logs without strict verdict headers return `UNKNOWN_VERDICT`. Both still fail closed through `_require_review_approved`.
+- verification: `test_review_verdict_requires_strict_header`
+
+### 6. MEDIUM `run_review_with_script` trusts `review.sh` existence and executability
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: a symlinked or non-executable review wrapper should not be spawned.
+- action: `run_review_with_script` now verifies `scripts/review.sh` is a single-link regular executable file before `subprocess.run`.
+- verification: `test_review_script_must_be_regular_executable_file`
+
+### 7. MEDIUM `write_complete_strategy_spec` lacks post-write verification
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: callers had no digest proving the atomically written bytes matched the intended content.
+- action: the writer now re-reads the file after atomic write, verifies byte equality, and returns `content_sha256`.
+- verification: `test_writes_complete_strategy_spec_that_passes_ship_shape`
+
+### 8. MEDIUM `verify_and_generate_thesis` does not validate `generate_func` return type
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: an injected helper returning `None` could produce a malformed success wrapper.
+- action: the adapter now requires `generate_func` to return `scripts.lib.invest_thesis.ThesisResult`.
+- verification: `test_generate_func_must_return_thesis_result`
+
+## Post-Fix Verification
+
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py -q` -> 31 passed
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py tests/test_invest_thesis.py tests/test_invest_coach.py tests/test_invest_ship_strategy.py -q` -> 273 passed
+- `python3 -m pytest tests/ -q` -> 1799 passed, 1 skipped, 53 subtests passed, 2 dependency warnings
+- `python3 scripts/lib/deploy_config.py preflight` -> passed

--- a/.code-reviews/orchestrator-adapters-round-6-response.md
+++ b/.code-reviews/orchestrator-adapters-round-6-response.md
@@ -1,0 +1,92 @@
+# Orchestrator Adapters Review Round 6 Response
+
+Review artifact: `.code-reviews/2026-06-04T15-33-18Z_e1f034.log`
+
+Reviewer metadata: `primary_used=minimax`, `fallback_used=false`
+
+Verdict: `NEEDS-ATTENTION`
+
+Architect ruling: K2B PM endorsed a bounded closeout. Fix only adapter-local issues that preserve the original expose-as-callable goal. Reject distributed locking, server-side token stores, and atomic-writer redesign as out of scope for single-operator, single-Mac, paper-trading deployment.
+
+## Finding Disposition
+
+### 1. CRITICAL rollback working-tree restore proceeds after failed index cleanup
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: refusing before working-tree restoration can leave the file in approved state after commit/index failures.
+- action: rollback now attempts working-tree restoration even when index cleanup fails, while preserving and surfacing index cleanup errors in the final `OrchestratorGateError`.
+- verification: `test_dirty_index_blocks_working_tree_restore_after_commit_failure`
+
+### 2. CRITICAL stale lock marker not cleared on unclean shutdown
+
+- reproduce: yes for marker design, but threat model rejected
+- material-to-live-risk: no for this deployment
+- disposition: rejected as out of scope
+- evidence: K2B PM clarified this is a single-operator, single-Mac, paper-trading deployment. Same-checkout `flock` plus external `ship_lease_id` covers the real concurrency risk.
+- action: removed the pending-marker mechanism rather than adding TTL, heartbeat, or PID-liveness recovery.
+- deferral: distributed lease durability belongs in the external orchestrator if deployment topology changes.
+
+### 3. HIGH approval token uses client-provided timestamp enabling replay
+
+- reproduce: yes
+- material-to-live-risk: not in this adapter's ownership boundary
+- disposition: rejected as out of scope, deferred by design
+- evidence: the adapter consumes an explicit human approval token captured by the orchestrator. Server-side nonces, consumed-token stores, and replay ledgers require orchestrator protocol state.
+- action: kept adapter token binding to slug, pre-approval file hash, `approved_at`, and `ship_lease_id`; removed nonce/microsecond hardening from this adapter pass.
+- deferral: approval-token replay protection belongs in the orchestrator protocol handoff #2 and should be implemented there.
+
+### 4. HIGH path traversal in review envelope `log_path` via symlink attack
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: a review envelope log path should not point at arbitrary repo-relative or symlinked files.
+- action: envelope validation now requires exactly `.code-reviews/<job_id>.log`, rejects traversal, verifies containment, and uses `lstat()` to require a regular non-symlink log file.
+- verification: `test_review_envelope_rejects_symlink_log_path`
+
+### 5. HIGH commit message trailer injection via `hints.trailers`
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: injected approve handlers could return trailer strings with newlines or malformed trailer content.
+- action: `_build_strategy_commit_message` now validates every trailer line with `_safe_trailer_line` before appending it.
+- verification: `test_commit_message_rejects_unsafe_trailer_line`
+
+### 6. HIGH race condition between file stat and read in rollback verification
+
+- reproduce: theoretical local attacker race
+- material-to-live-risk: no for this deployment
+- disposition: rejected as out of scope
+- evidence: the current adapter already refuses symlink, hardlink, and special-file strategy paths before mutation and before rollback. The remaining concern requires a hostile local actor racing file replacement between checks.
+- action: no O_NOFOLLOW atomic-writer redesign in this adapter pass.
+- deferral: if K2Bi later runs in a multi-user or hostile-filesystem environment, redesign the shared atomic writer centrally rather than inside this adapter.
+
+### 7. MEDIUM no validation that review script arguments match expected schema
+
+- reproduce: yes
+- material-to-live-risk: yes
+- disposition: accepted
+- evidence: file-list values are comma-joined before being passed to `scripts/review.sh`; commas, traversal, or control characters would corrupt scope.
+- action: review file and plan arguments now pass through repo-contained, comma-free, control-character-free validation before spawning the review wrapper.
+- verification: `test_review_script_rejects_unsafe_file_list`
+
+### 8. MEDIUM missing timeout constant on git rev-parse in `_repo_root_for`
+
+- reproduce: yes
+- material-to-live-risk: low
+- disposition: accepted
+- evidence: the repo-root probe used an inline timeout value while other subprocess gates use named constants.
+- action: added `REPO_ROOT_TIMEOUT_S`.
+- verification: covered by `test_repo_root_probe_fails_closed_outside_git` plus py_compile.
+
+## Post-Fix Verification
+
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py -q` -> 32 passed
+- `python3 -m pytest tests/test_invest_orchestrator_adapters.py tests/test_invest_thesis.py tests/test_invest_coach.py tests/test_invest_ship_strategy.py -q` -> 274 passed
+- `python3 -m pytest tests/ -q` -> 1800 passed, 1 skipped, 53 subtests passed, 2 dependency warnings
+- `python3 scripts/lib/deploy_config.py preflight` -> passed
+- `python3 -m py_compile scripts/lib/invest_orchestrator_adapters.py` -> passed
+- `git diff --check` -> passed

--- a/.code-reviews/orchestrator-adapters-round-7-response.md
+++ b/.code-reviews/orchestrator-adapters-round-7-response.md
@@ -1,0 +1,72 @@
+# Orchestrator Adapters Round 7 Disposition
+
+Date: 2026-06-06
+
+Architect ruling: K2B PM reframed this adapter as upstream of the engine gate. The engine only loads `status: approved` strategies with traceable `approved_commit_sha`, so a half-shipped or malformed strategy cannot reach the engine. Round 7 findings are correctness and recoverability issues, not capital-leak paths.
+
+Terminal instruction: apply one final bounded patch, run one more Kimi review, then raise the PR no matter what the verdict says. Remaining `NEEDS-ATTENTION` items after this disposition are reviewer-scope-bounded and return to Keith's K2Bi PM review of the PR.
+
+## Final Review
+
+- job_id: `2026-06-06T07-35-03Z_2459b9`
+- reviewer: `primary_used=minimax`, `fallback_used=false`
+- verdict: `NEEDS-ATTENTION`
+- outcome: no further code changes per Round 7 hard stop. PR is the terminal handoff to Keith's K2Bi PM review.
+
+## Finding Disposition
+
+### 1. Rollback recoverability
+
+- disposition: ACCEPTED, bounded.
+- action: added a persistent same-checkout rollback marker under `.k2bi-orchestrator/rollback/`.
+- action: `run_full_ship` refuses before review if an incomplete rollback marker exists.
+- action: rollback failures now attach a structured `RollbackResult` to `OrchestratorGateError`, including marker path, index restoration status, working-tree restoration status, and marker cleanup status.
+- boundary: no recovery daemon, no distributed durability, no TTL or heartbeat.
+
+### 2. Lock directory inside `.git`
+
+- disposition: ACCEPTED, narrow.
+- action: moved same-checkout lock files to `.k2bi-orchestrator/locks/`.
+- action: added containment validation for derived lock paths.
+- action: added `.k2bi-orchestrator/` to `.gitignore`.
+- boundary: still a local `flock` only. No distributed lock.
+
+### 3. Approval token timezone
+
+- disposition: ACCEPTED.
+- action: `approved_at` must parse as ISO-8601 with timezone and UTC offset.
+- boundary: replay prevention remains deferred to the orchestrator protocol.
+
+### 4. Strategy write verification
+
+- disposition: ACCEPTED.
+- action: `write_complete_strategy_spec` now verifies the post-write digest through `_sha256_file_descriptor`.
+- boundary: no `O_NOFOLLOW` shared atomic-writer redesign in this adapter.
+
+### 5. Broad stderr check
+
+- disposition: REJECTED.
+- reason: the current behavior fails safe. A false failure blocks a ship and cannot leak capital.
+- action: no code change.
+
+### 6. `git commit --only` edge cases
+
+- disposition: PARTIAL.
+- check: no existing adapter-local Ship-1a clean-tree preflight was present before dispatch.
+- action: added one narrow `git status --porcelain=v1 --untracked-files=no --ignore-submodules=none` assertion before mutation. It permits ordinary target strategy dirt and refuses unrelated, unmerged, or submodule state.
+- boundary: no broader Git workflow redesign.
+
+### 7. Mutable events
+
+- disposition: REJECTED.
+- reason: cleanliness only. It is not a safety risk under the PM reframing.
+- action: no code change.
+
+### 8. Subprocess default encoding
+
+- disposition: ACCEPTED, trivial only.
+- action: subprocess calls now pass `encoding="utf-8", errors="replace"`.
+
+## Deferred By Design
+
+Approval-token replay protection belongs in the orchestrator protocol handoff #2, where consumed-token or nonce state can be owned centrally. This adapter continues to bind the token to slug, content hash, UTC `approved_at`, and `ship_lease_id`, but it does not implement a server-side nonce store.

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ logs/
 # Codex/agent runtime artifacts (local-only state, never committed)
 .agents/
 .codex/
+.k2bi-orchestrator/
 
 # MiniMax review archive (local-only -- raw responses, prompts, usage log)
 .minimax-reviews/

--- a/scripts/lib/invest_orchestrator_adapters.py
+++ b/scripts/lib/invest_orchestrator_adapters.py
@@ -1,0 +1,1479 @@
+"""Callable safety adapters for external K2Bi orchestrators.
+
+The adapters in this module expose existing interactive K2Bi gates as typed
+functions. They do not weaken the underlying helpers. They add the missing
+operator evidence checks before delegating to the existing writer, strategy
+frontmatter, approval, review, and git paths.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Iterator
+from urllib.parse import urlparse
+
+import yaml
+
+from scripts.lib import invest_coach as ic
+from scripts.lib import invest_ship_strategy as iss
+from scripts.lib import invest_thesis as it
+from scripts.lib import strategy_frontmatter as sf
+
+
+MIN_TEXT_LEN = 1
+MIN_REASON_LEN = 20
+ALLOWED_OPERATOR_MARKS = frozenset({"verified", "refused", "override", "advisory"})
+_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_REVIEW_JOB_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z_[A-Za-z0-9]+$")
+_REVIEW_VERDICT_RE = re.compile(
+    r"^#\s+.+\breview\s+--\s+(APPROVE|NEEDS-ATTENTION)\s*$"
+)
+_SHIP_LEASE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,127}$")
+_ALLOWED_GIT_SUBCOMMANDS = frozenset(
+    {"add", "commit", "restore", "status", "diff", "reset"}
+)
+ORCHESTRATOR_STATE_DIR = ".k2bi-orchestrator"
+GIT_TIMEOUT_S = 30
+REPO_ROOT_TIMEOUT_S = 5
+REVIEW_TIMEOUT_S = 420
+MAX_REVIEW_FOCUS_LEN = 2_000
+
+
+@dataclass(frozen=True)
+class RollbackResult:
+    """Structured rollback outcome for a failed full-ship attempt."""
+
+    strategy_path: str
+    original_sha256: str
+    marker_path: str
+    index_restored: bool
+    working_tree_restored: bool
+    marker_cleared: bool
+    events: tuple[dict[str, Any], ...]
+
+
+class OrchestratorGateError(ValueError):
+    """Raised when an adapter refuses a safety or completeness gate."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        rollback_result: RollbackResult | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.rollback_result = rollback_result
+
+
+@dataclass(frozen=True)
+class ThesisClaimDecision:
+    """Operator-marked T7 claim evidence from an external orchestrator."""
+
+    claim_id: str
+    claim_text: str
+    claim_load_bearing: bool
+    source_url: str | None
+    source_excerpt: str
+    curated_framing: str
+    operator_mark: str
+    operator_note: str | None
+    source_vendor: str
+    spot_check_vendor: str | None = None
+
+
+@dataclass(frozen=True)
+class ThesisGateResult:
+    thesis_result: it.ThesisResult
+    audit: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StrategySpecDecision:
+    """Confirmed T10/T11 decisions needed to author a full strategy file."""
+
+    slug: str
+    symbol: str
+    sigid: str
+    risk_envelope_pct: Any
+    order: dict[str, Any]
+    forward_guidance_metrics: list[dict[str, Any]]
+    forward_guidance_status: str
+    how_this_works: str
+    bucket_rules: list[str]
+    entry_rules: list[str]
+    stop_rules: list[str]
+    target_rules: list[str]
+    hold_rules: list[str]
+    kill_rules: list[str]
+    accepted_gaps: list[str]
+    forward_guidance_override_reason: str | None = None
+    forward_guidance_waive_reason: str | None = None
+    regime_filter: list[Any] | None = None
+    date: str | None = None
+    extra_frontmatter: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class StrategySpecWriteResult:
+    path: Path
+    frontmatter: dict[str, Any]
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class FullShipApproval:
+    """Human final approval captured by the orchestrator ship gate."""
+
+    final_approval_token: str
+    approved_by: str
+    approved_at: str
+    ship_lease_id: str
+
+
+@dataclass(frozen=True)
+class ReviewRequest:
+    kind: str
+    path: Path
+    files: list[str]
+    focus: str
+    required_primary: str = "minimax"
+
+
+@dataclass(frozen=True)
+class ReviewGateResult:
+    verdict: str
+    primary_used: str | None
+    fallback_used: bool | None
+    log_path: str
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class FullShipResult:
+    slug: str
+    commit_message: str
+    commit_hints: iss.StrategyCommitHints
+    plan_review: ReviewGateResult
+    diff_review: ReviewGateResult
+    events: list[dict[str, Any]]
+
+
+GenerateThesisFunc = Callable[..., it.ThesisResult]
+ApproveStrategyFunc = Callable[..., iss.StrategyCommitHints]
+ReviewRunner = Callable[[ReviewRequest], ReviewGateResult]
+GitRunner = Callable[[list[str], Path], CommandResult]
+
+
+def verify_and_generate_thesis(
+    thesis_input: it.ThesisInput,
+    vault_root: Path,
+    *,
+    claim_decisions: list[ThesisClaimDecision],
+    operator_override_reason: str | None = None,
+    calx_override_acknowledged: bool = False,
+    vendor_warning_acknowledged: bool = False,
+    vendor_provenance: dict[str, Any] | None = None,
+    generate_func: GenerateThesisFunc = it.generate_thesis,
+    refresh: bool = False,
+    learning_stage: str = "advanced",
+    now: _dt.date | None = None,
+) -> ThesisGateResult:
+    """Enforce T7 evidence discipline before writing a thesis.
+
+    The existing ``generate_thesis`` helper validates the aggregate
+    verification block. This adapter validates the evidence the interactive
+    coach requires before that block may exist: excerpts, source URLs, vendor
+    provenance, vendor-must-differ, and CALX override framing.
+    """
+
+    audit = _validate_thesis_claim_decisions(
+        claim_decisions,
+        operator_override_reason=operator_override_reason,
+        calx_override_acknowledged=calx_override_acknowledged,
+        vendor_warning_acknowledged=vendor_warning_acknowledged,
+        vendor_provenance=vendor_provenance,
+    )
+
+    claim_dicts = [_claim_decision_to_verification_dict(c) for c in claim_decisions]
+    try:
+        verification_dict = ic.build_verification_result(
+            claim_dicts,
+            vendor_provenance=vendor_provenance,
+            operator_override_reason=operator_override_reason,
+        )
+    except ValueError as exc:
+        raise OrchestratorGateError(str(exc)) from exc
+
+    if verification_dict["status"] == "refuse":
+        raise OrchestratorGateError(
+            verification_dict.get("refuse_reason")
+            or "verification gate refused before thesis generation"
+        )
+
+    verification = it.Verification(
+        completed_at=str(verification_dict["completed_at"]),
+        claims=[
+            it.ClaimVerification(
+                claim_id=str(c["claim_id"]),
+                claim_text=str(c["claim_text"]),
+                claim_load_bearing=bool(c["claim_load_bearing"]),
+                source_url=c.get("source_url"),
+                operator_check=str(c["operator_check"]),
+                operator_note=c.get("operator_note"),
+            )
+            for c in claim_dicts
+        ],
+        status=str(verification_dict["status"]),
+        override_reason=verification_dict.get("override_reason"),
+        refuse_reason=verification_dict.get("refuse_reason"),
+    )
+
+    gated_input = replace(thesis_input, verification=verification)
+    try:
+        thesis_result = generate_func(
+            gated_input,
+            vault_root,
+            refresh=refresh,
+            learning_stage=learning_stage,
+            now=now,
+        )
+    except ValueError as exc:
+        raise OrchestratorGateError(str(exc)) from exc
+    if not isinstance(thesis_result, it.ThesisResult):
+        raise OrchestratorGateError(
+            "generate_func must return scripts.lib.invest_thesis.ThesisResult"
+        )
+    return ThesisGateResult(thesis_result=thesis_result, audit=audit)
+
+
+def write_complete_strategy_spec(
+    decision: StrategySpecDecision,
+    *,
+    repo_root: Path = Path("."),
+) -> StrategySpecWriteResult:
+    """Atomically write a complete proposed strategy file.
+
+    External callers pass confirmed T10/T11 decisions in. This function authors
+    the canonical file rather than letting the caller hand-write K2Bi state.
+    """
+
+    _validate_strategy_decision(decision)
+    strategy_path = repo_root / "wiki" / "strategies" / f"strategy_{decision.slug}.md"
+
+    try:
+        frontmatter = ic.build_canonical_strategy_frontmatter(
+            name=decision.slug,
+            symbol=decision.symbol,
+            sigid=decision.sigid,
+            risk_envelope_pct=decision.risk_envelope_pct,
+            order=decision.order,
+            forward_guidance_metrics=decision.forward_guidance_metrics,
+            forward_guidance_status=decision.forward_guidance_status,
+            forward_guidance_override_reason=decision.forward_guidance_override_reason,
+            forward_guidance_waive_reason=decision.forward_guidance_waive_reason,
+            regime_filter=decision.regime_filter,
+            date=decision.date,
+            extra=decision.extra_frontmatter,
+        )
+    except ValueError as exc:
+        raise OrchestratorGateError(str(exc)) from exc
+
+    body = _render_strategy_body(decision)
+    content = _serialize_markdown(frontmatter, body)
+    try:
+        parsed = sf.parse(content)
+        iss._validate_strategy_shape(strategy_path, parsed, content)
+    except (ValueError, iss.ValidationError) as exc:
+        raise OrchestratorGateError(str(exc)) from exc
+
+    expected_sha = _sha256_bytes(content)
+    sf.atomic_write_bytes(strategy_path, content)
+    written_sha = _sha256_file_descriptor(strategy_path)
+    if written_sha != expected_sha:
+        raise OrchestratorGateError(
+            f"strategy spec write verification failed for {strategy_path!s}"
+        )
+    return StrategySpecWriteResult(
+        path=strategy_path,
+        frontmatter=frontmatter,
+        content_sha256=written_sha,
+    )
+
+
+def run_full_ship(
+    strategy_path: Path,
+    *,
+    approval: FullShipApproval,
+    review_runner: ReviewRunner | None = None,
+    approve_handler: ApproveStrategyFunc = iss.handle_approve_strategy,
+    git_runner: GitRunner | None = None,
+    vault_root: Path | None = None,
+    now: _dt.datetime | None = None,
+    today: _dt.date | None = None,
+    required_primary: str = "minimax",
+) -> FullShipResult:
+    """Run the callable full strategy approval ship path.
+
+    This wraps the existing ``approve-strategy`` helper with plan review,
+    explicit human final approval, diff review, staging, and commit. Any failed
+    pre-commit gate restores the original file bytes and refuses before commit.
+    The local flock prevents same-checkout interleaving. Cross-checkout or
+    distributed orchestrators must also pass a non-empty ``ship_lease_id`` from
+    their own mutual-exclusion layer, and the approval token binds that lease.
+    """
+
+    review_runner = review_runner or run_review_with_script
+    git_runner = git_runner or run_git_command
+    repo_root = _repo_root_for(strategy_path)
+    rel_path = _repo_relative(strategy_path, repo_root)
+    slug = _slug_from_strategy_path(strategy_path)
+    events: list[dict[str, Any]] = []
+
+    with _strategy_ship_lock(strategy_path, repo_root):
+        _refuse_if_incomplete_rollback(strategy_path, repo_root)
+        _assert_single_link_regular_file(strategy_path, "strategy file")
+        original = strategy_path.read_bytes()
+        original_sha = _sha256_bytes(original)
+        _validate_full_ship_approval(approval, slug, original_sha)
+        _assert_ship_clean_preflight(git_runner, repo_root, rel_path)
+        events.append(
+            {
+                "event": "ship_start",
+                "strategy": slug,
+                "path": rel_path,
+                "original_sha256": original_sha,
+                "approved_at": approval.approved_at,
+                "ship_lease_id": approval.ship_lease_id,
+            }
+        )
+        staged = False
+
+        plan_review = review_runner(
+            ReviewRequest(
+                kind="plan",
+                path=strategy_path,
+                files=[rel_path],
+                focus=_strategy_plan_review_focus(),
+                required_primary=required_primary,
+            )
+        )
+        events.append(_review_event("plan_review_completed", plan_review))
+        try:
+            _require_review_approved(plan_review, "plan review", required_primary)
+
+            hints = approve_handler(
+                strategy_path,
+                vault_root=vault_root,
+                now=now,
+                today=today,
+            )
+            events.append(
+                {
+                    "event": "approve_handler_completed",
+                    "strategy": hints.slug,
+                    "transition": hints.transition,
+                }
+            )
+
+            diff_review = review_runner(
+                ReviewRequest(
+                    kind="diff",
+                    path=strategy_path,
+                    files=[rel_path],
+                    focus="Review the strategy approval diff for gate bypass, missing trailers, or safety regression.",
+                    required_primary=required_primary,
+                )
+            )
+            events.append(_review_event("diff_review_completed", diff_review))
+            _require_review_approved(diff_review, "diff review", required_primary)
+
+            commit_message = _build_strategy_commit_message(
+                hints,
+                approval=approval,
+                plan_review=plan_review,
+                diff_review=diff_review,
+            )
+            _run_git_checked(
+                git_runner,
+                ["git", "add", rel_path],
+                repo_root,
+            )
+            staged = True
+            events.append({"event": "git_add_succeeded", "path": rel_path})
+            _run_git_checked(
+                git_runner,
+                ["git", "commit", "--only", rel_path, "-m", commit_message],
+                repo_root,
+            )
+            events.append({"event": "commit_succeeded", "path": rel_path})
+        except Exception as exc:
+            rollback_result = _rollback_ship_failure(
+                git_runner=git_runner,
+                repo_root=repo_root,
+                rel_path=rel_path,
+                strategy_path=strategy_path,
+                original=original,
+                original_sha=original_sha,
+                prior_exc=exc,
+                staged=staged,
+                events=events,
+            )
+            if isinstance(exc, OrchestratorGateError):
+                exc.rollback_result = rollback_result
+            raise
+
+        return FullShipResult(
+            slug=slug,
+            commit_message=commit_message,
+            commit_hints=hints,
+            plan_review=plan_review,
+            diff_review=diff_review,
+            events=events,
+        )
+
+
+def _rollback_ship_failure(
+    *,
+    git_runner: GitRunner,
+    repo_root: Path,
+    rel_path: str,
+    strategy_path: Path,
+    original: bytes,
+    original_sha: str,
+    prior_exc: Exception,
+    staged: bool,
+    events: list[dict[str, Any]],
+) -> RollbackResult:
+    """Restore working-tree and index state after a ship gate failure."""
+
+    marker_path = _rollback_marker_path_for(strategy_path, repo_root)
+    _write_rollback_marker(
+        marker_path,
+        rel_path=rel_path,
+        original_sha=original_sha,
+        phase="started",
+    )
+    unstage_exc: Exception | None = None
+    restore_exc: Exception | None = None
+    index_exc: Exception | None = None
+    index_restored = not staged
+    working_tree_restored = False
+    marker_cleared = False
+    if staged:
+        _write_rollback_marker(
+            marker_path,
+            rel_path=rel_path,
+            original_sha=original_sha,
+            phase="index_cleanup",
+        )
+        try:
+            _run_git_checked(
+                git_runner,
+                ["git", "restore", "--staged", rel_path],
+                repo_root,
+            )
+            events.append({"event": "git_restore_staged_succeeded", "path": rel_path})
+            index_restored = True
+        except Exception as caught:
+            unstage_exc = caught
+            events.append(
+                {
+                    "event": "git_restore_staged_failed",
+                    "path": rel_path,
+                    "error": str(caught),
+                }
+            )
+            try:
+                _run_git_checked(
+                    git_runner,
+                    ["git", "reset", "HEAD", "--", rel_path],
+                    repo_root,
+                )
+                events.append({"event": "git_reset_head_succeeded", "path": rel_path})
+                index_restored = True
+            except Exception as reset_caught:
+                index_exc = reset_caught
+                events.append(
+                    {
+                        "event": "git_reset_head_failed",
+                        "path": rel_path,
+                        "error": str(reset_caught),
+                    }
+                )
+            if index_exc is None:
+                try:
+                    if not _is_index_clean(git_runner, repo_root, rel_path):
+                        index_exc = OrchestratorGateError(
+                            f"index still contains staged content for {rel_path}"
+                        )
+                except Exception as diff_caught:
+                    index_exc = diff_caught
+                if index_exc is not None:
+                    events.append(
+                        {
+                            "event": "index_clean_check_failed",
+                            "path": rel_path,
+                            "error": str(index_exc),
+                        }
+                    )
+                    index_restored = False
+    try:
+        _write_rollback_marker(
+            marker_path,
+            rel_path=rel_path,
+            original_sha=original_sha,
+            phase="working_tree_restore",
+        )
+        _restore_original_or_raise(strategy_path, original, original_sha, prior_exc)
+        events.append({"event": "working_tree_restore_succeeded", "path": rel_path})
+        working_tree_restored = True
+    except Exception as caught:
+        restore_exc = caught
+        events.append(
+            {
+                "event": "working_tree_restore_failed",
+                "path": rel_path,
+                "error": str(caught),
+            }
+        )
+
+    rollback_result = RollbackResult(
+        strategy_path=rel_path,
+        original_sha256=original_sha,
+        marker_path=str(marker_path),
+        index_restored=index_restored,
+        working_tree_restored=working_tree_restored,
+        marker_cleared=False,
+        events=tuple(events),
+    )
+
+    if unstage_exc is not None or restore_exc is not None:
+        details = [
+            f"original ship error: {prior_exc!r}",
+        ]
+        if unstage_exc is not None:
+            details.append(f"git restore --staged error: {unstage_exc!r}")
+        if index_exc is not None:
+            details.append(f"index cleanup error: {index_exc!r}")
+        if restore_exc is not None:
+            details.append(f"working-tree restore error: {restore_exc!r}")
+        raise OrchestratorGateError(
+            "; ".join(details),
+            rollback_result=rollback_result,
+        ) from (
+            restore_exc or index_exc or unstage_exc
+        )
+
+    try:
+        marker_path.unlink()
+        marker_cleared = True
+    except FileNotFoundError:
+        marker_cleared = True
+    except OSError as exc:
+        failed_result = RollbackResult(
+            strategy_path=rel_path,
+            original_sha256=original_sha,
+            marker_path=str(marker_path),
+            index_restored=index_restored,
+            working_tree_restored=working_tree_restored,
+            marker_cleared=False,
+            events=tuple(events),
+        )
+        raise OrchestratorGateError(
+            f"rollback marker cleanup failed for {marker_path!s}",
+            rollback_result=failed_result,
+        ) from exc
+
+    return RollbackResult(
+        strategy_path=rel_path,
+        original_sha256=original_sha,
+        marker_path=str(marker_path),
+        index_restored=index_restored,
+        working_tree_restored=working_tree_restored,
+        marker_cleared=marker_cleared,
+        events=tuple(events),
+    )
+
+
+def _is_index_clean(git_runner: GitRunner, repo_root: Path, rel_path: str) -> bool:
+    result = git_runner(
+        ["git", "diff", "--cached", "--quiet", "--", rel_path],
+        repo_root,
+    )
+    if not isinstance(result, CommandResult):
+        raise OrchestratorGateError(
+            f"git runner must return CommandResult for index check on {rel_path}"
+        )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise OrchestratorGateError(
+        f"git diff --cached --quiet failed with exit {result.returncode}: "
+        f"{result.stderr.strip() or result.stdout.strip()}"
+    )
+
+
+def _assert_ship_clean_preflight(
+    git_runner: GitRunner,
+    repo_root: Path,
+    rel_path: str,
+) -> None:
+    result = git_runner(
+        [
+            "git",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=no",
+            "--ignore-submodules=none",
+        ],
+        repo_root,
+    )
+    if not isinstance(result, CommandResult):
+        raise OrchestratorGateError(
+            f"git runner must return CommandResult for clean-tree preflight on {rel_path}"
+        )
+    if result.returncode != 0:
+        raise OrchestratorGateError(
+            "Ship-1a clean-tree preflight git status failed with exit "
+            f"{result.returncode}: {result.stderr.strip() or result.stdout.strip()}"
+        )
+
+    dirty = []
+    for raw_line in result.stdout.splitlines():
+        if not raw_line:
+            continue
+        if _status_line_is_allowed_target_change(raw_line, rel_path):
+            continue
+        dirty.append(raw_line)
+
+    if dirty:
+        preview = "; ".join(dirty[:5])
+        raise OrchestratorGateError(
+            "Ship-1a clean-tree preflight refused unrelated, unmerged, or "
+            f"submodule state before ship: {preview}"
+        )
+
+
+def _status_line_is_allowed_target_change(raw_line: str, rel_path: str) -> bool:
+    if len(raw_line) < 4:
+        return False
+    status = raw_line[:2]
+    paths = _status_line_paths(raw_line)
+    if paths != [rel_path]:
+        return False
+    if "U" in status:
+        return False
+    return status in {" M", "M ", "MM", "A ", "AM"}
+
+
+def _status_line_paths(raw_line: str) -> list[str]:
+    path_text = raw_line[3:]
+    if " -> " in path_text:
+        return path_text.split(" -> ", 1)
+    return [path_text]
+
+
+@contextmanager
+def _strategy_ship_lock(strategy_path: Path, repo_root: Path) -> Iterator[None]:
+    lock_path = _lock_path_for(strategy_path, repo_root)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise OrchestratorGateError(
+                f"strategy {strategy_path.name!r} is already locked for full ship"
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _lock_path_for(strategy_path: Path, repo_root: Path) -> Path:
+    slug = _slug_from_strategy_path(strategy_path)
+    _validate_slug(slug)
+    lock_dir = _orchestrator_state_path(repo_root, "locks")
+    return _contained_child_path(lock_dir / f"{slug}.lock", lock_dir, "lock path")
+
+
+def _rollback_marker_path_for(strategy_path: Path, repo_root: Path) -> Path:
+    slug = _slug_from_strategy_path(strategy_path)
+    _validate_slug(slug)
+    marker_dir = _orchestrator_state_path(repo_root, "rollback")
+    return _contained_child_path(marker_dir / f"{slug}.json", marker_dir, "rollback marker")
+
+
+def _orchestrator_state_path(repo_root: Path, name: str) -> Path:
+    _validate_slug(name)
+    state_root = repo_root / ORCHESTRATOR_STATE_DIR
+    return _contained_child_path(state_root / name, state_root, "orchestrator state path")
+
+
+def _contained_child_path(path: Path, base: Path, label: str) -> Path:
+    resolved_base = base.resolve(strict=False)
+    resolved_path = path.resolve(strict=False)
+    try:
+        resolved_path.relative_to(resolved_base)
+    except ValueError as exc:
+        raise OrchestratorGateError(
+            f"{label} escapes expected directory {resolved_base!s}: {path!s}"
+        ) from exc
+    return path
+
+
+def _write_rollback_marker(
+    marker_path: Path,
+    *,
+    rel_path: str,
+    original_sha: str,
+    phase: str,
+) -> None:
+    payload = {
+        "strategy_path": rel_path,
+        "original_sha256": original_sha,
+        "phase": phase,
+        "updated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+    sf.atomic_write_bytes(
+        marker_path,
+        (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8"),
+    )
+
+
+def _refuse_if_incomplete_rollback(strategy_path: Path, repo_root: Path) -> None:
+    marker_path = _rollback_marker_path_for(strategy_path, repo_root)
+    if not marker_path.exists():
+        return
+    rel_marker = _repo_relative(marker_path, repo_root)
+    try:
+        payload = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OrchestratorGateError(
+            f"incomplete rollback marker exists and is unreadable: {rel_marker}"
+        ) from exc
+    marker_strategy = payload.get("strategy_path")
+    phase = payload.get("phase", "unknown")
+    raise OrchestratorGateError(
+        "incomplete rollback marker exists for "
+        f"{marker_strategy or strategy_path.name} at phase {phase!r}: {rel_marker}"
+    )
+
+
+def _review_event(event: str, review: ReviewGateResult) -> dict[str, Any]:
+    return {
+        "event": event,
+        "verdict": review.verdict,
+        "primary_used": review.primary_used,
+        "fallback_used": review.fallback_used,
+        "log_path": review.log_path,
+    }
+
+
+def run_git_command(cmd: list[str], cwd: Path) -> CommandResult:
+    """Run a git command and return a small typed result."""
+
+    _validate_git_command(cmd)
+    completed = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        timeout=GIT_TIMEOUT_S,
+    )
+    return CommandResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def run_review_with_script(request: ReviewRequest) -> ReviewGateResult:
+    """Run ``scripts/review.sh`` synchronously and return typed review state."""
+
+    repo_root = _repo_root_for(request.path)
+    focus = _safe_review_focus(request.focus)
+    review_script = repo_root / "scripts" / "review.sh"
+    _assert_executable_regular_file(review_script, "review script")
+    cmd = [
+        str(review_script),
+        request.kind,
+    ]
+    if request.kind == "plan":
+        cmd.extend(["--plan", _safe_review_path(request.path, repo_root, "review plan")])
+    elif request.kind == "diff":
+        cmd.extend(["--files", ",".join(_safe_review_files(request.files, repo_root))])
+    else:
+        raise OrchestratorGateError(
+            f"unsupported review kind {request.kind!r}; expected plan or diff"
+        )
+    cmd.extend([
+        "--primary",
+        request.required_primary,
+        "--focus",
+        focus,
+        "--wait",
+    ])
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            timeout=REVIEW_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise OrchestratorGateError(
+            f"{request.kind} review timed out after {REVIEW_TIMEOUT_S}s"
+        ) from exc
+    if completed.returncode != 0:
+        raise OrchestratorGateError(
+            f"{request.kind} review failed with exit {completed.returncode}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+    if completed.stderr.strip():
+        raise OrchestratorGateError(
+            f"{request.kind} review returned stderr despite exit 0: "
+            f"{completed.stderr.strip()}"
+        )
+    try:
+        envelope = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise OrchestratorGateError(
+            f"{request.kind} review returned non-JSON output"
+        ) from exc
+
+    job_id = envelope.get("job_id")
+    log_path = _validate_review_envelope(envelope, repo_root)
+    state_path = repo_root / ".code-reviews" / f"{job_id}.json"
+    state = _load_review_state(state_path)
+    verdict = _extract_review_verdict(log_path)
+    return ReviewGateResult(
+        verdict=verdict,
+        primary_used=state.get("primary_used"),
+        fallback_used=state.get("fallback_used"),
+        log_path=(
+            str(log_path.relative_to(repo_root.resolve()))
+            if log_path.exists()
+            else str(log_path)
+        ),
+    )
+
+
+def strategy_file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest of the strategy file bytes."""
+
+    return _sha256_bytes(path.read_bytes())
+
+
+def _validate_thesis_claim_decisions(
+    claim_decisions: list[ThesisClaimDecision],
+    *,
+    operator_override_reason: str | None,
+    calx_override_acknowledged: bool,
+    vendor_warning_acknowledged: bool,
+    vendor_provenance: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not claim_decisions:
+        raise OrchestratorGateError("claim_decisions must not be empty")
+    if vendor_provenance and not vendor_warning_acknowledged:
+        vendor = vendor_provenance.get("vendor", "unknown vendor")
+        raise OrchestratorGateError(
+            f"T7 vendor warning for {vendor!r} must be acknowledged before generation"
+        )
+
+    override_marks_present = False
+    audit_claims: list[dict[str, Any]] = []
+    for claim in claim_decisions:
+        _validate_claim_basics(claim)
+        if claim.claim_load_bearing:
+            _validate_load_bearing_claim_evidence(claim, vendor_provenance)
+        mark = claim.operator_mark.strip().lower()
+        if mark in {"refused", "override"} and claim.claim_load_bearing:
+            override_marks_present = True
+        audit_claims.append(_claim_decision_to_audit(claim))
+
+    if override_marks_present:
+        if not operator_override_reason or len(operator_override_reason.strip()) < MIN_REASON_LEN:
+            raise OrchestratorGateError(
+                f"operator_override_reason >= {MIN_REASON_LEN} chars is required "
+                "when a load-bearing claim is refused or overridden"
+            )
+        if not calx_override_acknowledged:
+            raise OrchestratorGateError(
+                "override path requires explicit CALX framing acknowledgement "
+                "(L-2026-04-30-001)"
+            )
+
+    return {
+        "completed_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "calx_override_acknowledged": calx_override_acknowledged,
+        "vendor_warning_acknowledged": vendor_warning_acknowledged,
+        "claims": audit_claims,
+    }
+
+
+def _validate_claim_basics(claim: ThesisClaimDecision) -> None:
+    _require_text("claim_id", claim.claim_id)
+    _require_text("claim_text", claim.claim_text)
+    mark = claim.operator_mark.strip().lower() if isinstance(claim.operator_mark, str) else ""
+    if mark not in ALLOWED_OPERATOR_MARKS:
+        raise OrchestratorGateError(
+            f"claim {claim.claim_id!r} operator_mark {claim.operator_mark!r} "
+            f"must be one of {sorted(ALLOWED_OPERATOR_MARKS)}"
+        )
+    if mark in {"refused", "override"}:
+        note = claim.operator_note or ""
+        if len(note.strip()) < MIN_REASON_LEN:
+            raise OrchestratorGateError(
+                f"claim {claim.claim_id!r} operator_mark={mark!r} requires "
+                f"operator_note >= {MIN_REASON_LEN} chars"
+            )
+
+
+def _validate_load_bearing_claim_evidence(
+    claim: ThesisClaimDecision,
+    vendor_provenance: dict[str, Any] | None,
+) -> None:
+    _require_text(f"claim {claim.claim_id} source_excerpt", claim.source_excerpt)
+    _require_text(f"claim {claim.claim_id} curated_framing", claim.curated_framing)
+    _require_text(f"claim {claim.claim_id} source_vendor", claim.source_vendor)
+    _validate_http_url(f"claim {claim.claim_id} source_url", claim.source_url)
+    if claim.spot_check_vendor:
+        if _same_vendor(claim.spot_check_vendor, claim.source_vendor):
+            raise OrchestratorGateError(
+                f"claim {claim.claim_id!r} violates vendor-must-differ: "
+                "spot_check_vendor matches source_vendor"
+            )
+        t55_vendor = (vendor_provenance or {}).get("vendor")
+        if t55_vendor and _same_vendor(claim.spot_check_vendor, str(t55_vendor)):
+            raise OrchestratorGateError(
+                f"claim {claim.claim_id!r} violates vendor-must-differ: "
+                "spot_check_vendor matches T5.5 vendor"
+            )
+
+
+def _claim_decision_to_verification_dict(claim: ThesisClaimDecision) -> dict[str, Any]:
+    mark = claim.operator_mark.strip().lower()
+    operator_check = "refused" if mark == "override" else mark
+    return {
+        "claim_id": claim.claim_id,
+        "claim_text": claim.claim_text,
+        "claim_load_bearing": claim.claim_load_bearing,
+        "source_url": claim.source_url,
+        "operator_check": operator_check,
+        "operator_note": claim.operator_note,
+    }
+
+
+def _claim_decision_to_audit(claim: ThesisClaimDecision) -> dict[str, Any]:
+    return {
+        "claim_id": claim.claim_id,
+        "claim_text": claim.claim_text,
+        "claim_load_bearing": claim.claim_load_bearing,
+        "source_url": claim.source_url,
+        "source_excerpt": claim.source_excerpt,
+        "curated_framing": claim.curated_framing,
+        "operator_mark": claim.operator_mark,
+        "operator_note": claim.operator_note,
+        "source_vendor": claim.source_vendor,
+        "spot_check_vendor": claim.spot_check_vendor,
+    }
+
+
+def _validate_strategy_decision(decision: StrategySpecDecision) -> None:
+    _validate_slug(decision.slug)
+    _require_text("symbol", decision.symbol)
+    _require_text("sigid", decision.sigid)
+    _require_text("How This Works", decision.how_this_works)
+    for label, items in [
+        ("bucket_rules", decision.bucket_rules),
+        ("entry_rules", decision.entry_rules),
+        ("stop_rules", decision.stop_rules),
+        ("target_rules", decision.target_rules),
+        ("hold_rules", decision.hold_rules),
+        ("kill_rules", decision.kill_rules),
+        ("accepted_gaps", decision.accepted_gaps),
+    ]:
+        _require_text_list(label, items)
+
+
+def _render_strategy_body(decision: StrategySpecDecision) -> str:
+    sections = [
+        f"# Strategy: {decision.slug}",
+        "",
+        "## How This Works",
+        "",
+        decision.how_this_works.strip(),
+        "",
+        _render_list_section("Bucket Rules", decision.bucket_rules),
+        _render_list_section("Entry Rules", decision.entry_rules),
+        _render_list_section("Stop Rules", decision.stop_rules),
+        _render_list_section("Target Rules", decision.target_rules),
+        _render_list_section("Hold Rules", decision.hold_rules),
+        _render_list_section("Kill Rules", decision.kill_rules),
+        _render_forward_guidance_summary(decision),
+        _render_list_section("Accepted Gaps", decision.accepted_gaps),
+        ic.render_accepted_gaps_section().strip(),
+        "",
+    ]
+    return "\n".join(sections)
+
+
+def _render_list_section(title: str, items: list[str]) -> str:
+    body = "\n".join(f"- {item.strip()}" for item in items)
+    return f"## {title}\n\n{body}\n"
+
+
+def _render_forward_guidance_summary(decision: StrategySpecDecision) -> str:
+    lines = [
+        "## Forward Guidance Reconciliation",
+        "",
+        f"- Status: {decision.forward_guidance_status}",
+    ]
+    if decision.forward_guidance_override_reason:
+        lines.append(f"- Override reason: {decision.forward_guidance_override_reason}")
+    if decision.forward_guidance_waive_reason:
+        lines.append(f"- Waive reason: {decision.forward_guidance_waive_reason}")
+    for metric in decision.forward_guidance_metrics:
+        name = metric.get("metric", "unknown")
+        threshold = metric.get("locked_threshold_text", "unknown threshold")
+        guide = metric.get("guide_range_text", "unknown guide")
+        inside = metric.get("sits_inside_guide")
+        lines.append(f"- {name}: {threshold}; guide={guide}; inside={inside}")
+    return "\n".join(lines) + "\n"
+
+
+def _serialize_markdown(frontmatter: dict[str, Any], body: str) -> bytes:
+    yaml_text = yaml.safe_dump(
+        frontmatter,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+    )
+    return f"---\n{yaml_text}---\n\n{body.rstrip()}\n".encode("utf-8")
+
+
+def _validate_full_ship_approval(
+    approval: FullShipApproval,
+    slug: str,
+    strategy_sha256: str,
+) -> None:
+    _require_text("approved_at", approval.approved_at)
+    try:
+        approved_at = _dt.datetime.fromisoformat(approval.approved_at)
+    except ValueError as exc:
+        raise OrchestratorGateError(
+            f"approved_at must be ISO-8601 datetime, got {approval.approved_at!r}"
+        ) from exc
+    if approved_at.tzinfo is None or approved_at.utcoffset() is None:
+        raise OrchestratorGateError(
+            "approved_at must include an explicit timezone offset"
+        )
+    if approved_at.utcoffset() != _dt.timedelta(0):
+        raise OrchestratorGateError("approved_at must be UTC")
+    _validate_ship_lease_id(approval.ship_lease_id)
+    expected = (
+        f"APPROVE_STRATEGY:{slug}:{strategy_sha256}:"
+        f"{approval.approved_at}:{approval.ship_lease_id}"
+    )
+    if approval.final_approval_token != expected:
+        raise OrchestratorGateError(
+            "final approval token must bind slug, content hash, approved_at, "
+            "and ship_lease_id as "
+            f"{expected!r}; got "
+            f"{approval.final_approval_token!r}"
+        )
+    _require_text("approved_by", approval.approved_by)
+
+
+def _require_review_approved(
+    review: ReviewGateResult,
+    label: str,
+    required_primary: str,
+) -> None:
+    if review.verdict != "APPROVE":
+        raise OrchestratorGateError(
+            f"{label} refused: verdict={review.verdict!r} log={review.log_path}"
+        )
+    if review.primary_used != required_primary or review.fallback_used is not False:
+        raise OrchestratorGateError(
+            f"{label} must use primary_used={required_primary} and "
+            f"fallback_used=false; got primary_used={review.primary_used!r}, "
+            f"fallback_used={review.fallback_used!r}"
+        )
+
+
+def _run_git_checked(git_runner: GitRunner, cmd: list[str], cwd: Path) -> None:
+    result = git_runner(cmd, cwd)
+    if not isinstance(result, CommandResult):
+        raise OrchestratorGateError(
+            f"git runner must return CommandResult for {' '.join(cmd)}"
+        )
+    if result.returncode != 0:
+        raise OrchestratorGateError(
+            f"{' '.join(cmd)} failed with exit {result.returncode}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+
+
+def _build_strategy_commit_message(
+    hints: iss.StrategyCommitHints,
+    *,
+    approval: FullShipApproval,
+    plan_review: ReviewGateResult,
+    diff_review: ReviewGateResult,
+) -> str:
+    lines = [
+        hints.commit_subject,
+        "",
+        f"Approved-By: {_safe_commit_field('approved_by', approval.approved_by)}",
+        f"Approval-Captured-At: {_safe_commit_field('approved_at', approval.approved_at)}",
+        f"Plan-Review-Log: {_safe_commit_field('plan_review.log_path', plan_review.log_path)}",
+        f"Diff-Review-Log: {_safe_commit_field('diff_review.log_path', diff_review.log_path)}",
+        "",
+    ]
+    lines.extend(_safe_trailer_line(line) for line in hints.trailers)
+    return "\n".join(lines)
+
+
+def _strategy_plan_review_focus() -> str:
+    return (
+        "Review this proposed strategy spec for look-ahead bias, unrealistic "
+        "order assumptions, regime_filter mismatch, weak How This Works clarity, "
+        "and any K2Bi safety gate bypass."
+    )
+
+
+def _extract_review_verdict(log_path: Path) -> str:
+    if not log_path.is_file():
+        return "LOG_MISSING"
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = _REVIEW_VERDICT_RE.match(line.strip())
+        if match:
+            return match.group(1)
+        if line.lstrip().startswith("{"):
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            verdict = payload.get("verdict")
+            if verdict in {"APPROVE", "NEEDS-ATTENTION"}:
+                return str(verdict)
+    return "UNKNOWN_VERDICT"
+
+
+def _slug_from_strategy_path(path: Path) -> str:
+    stem = path.stem
+    if not stem.startswith("strategy_"):
+        raise OrchestratorGateError(
+            f"strategy path must be named strategy_<slug>.md, got {path.name!r}"
+        )
+    slug = stem[len("strategy_"):]
+    _validate_slug(slug)
+    return slug
+
+
+def _repo_root_for(path: Path) -> Path:
+    try:
+        root = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(path.parent),
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stderr=subprocess.DEVNULL,
+            timeout=REPO_ROOT_TIMEOUT_S,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise OrchestratorGateError(
+            f"cannot determine git repository root for {path!s}; refusing "
+            "to continue because full ship requires a real git checkout"
+        ) from exc
+    if not root:
+        raise OrchestratorGateError(
+            f"cannot determine git repository root for {path!s}; got empty git output"
+        )
+    return Path(root)
+
+
+def _repo_relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise OrchestratorGateError(
+            f"path {path!s} resolves outside repo root {repo_root!s}; "
+            "refusing to pass an absolute or escaped path to git"
+        ) from exc
+
+
+def _validate_slug(slug: str) -> None:
+    if not isinstance(slug, str) or not _SLUG_RE.match(slug):
+        raise OrchestratorGateError(
+            f"slug must match {_SLUG_RE.pattern}, got {slug!r}"
+        )
+
+
+def _validate_http_url(label: str, value: str | None) -> None:
+    _require_text(label, value)
+    parsed = urlparse(str(value))
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise OrchestratorGateError(
+            f"{label} must be HTTP/HTTPS with a host, got {value!r}"
+        )
+
+
+def _require_text(label: str, value: Any, min_len: int = MIN_TEXT_LEN) -> None:
+    if not isinstance(value, str) or len(value.strip()) < min_len:
+        raise OrchestratorGateError(
+            f"{label} must be a non-empty string"
+        )
+
+
+def _require_text_list(label: str, items: list[str]) -> None:
+    if not isinstance(items, list) or not items:
+        raise OrchestratorGateError(f"{label} must be a non-empty list")
+    for i, item in enumerate(items):
+        _require_text(f"{label}[{i}]", item)
+
+
+def _same_vendor(a: str, b: str) -> bool:
+    return a.strip().lower() == b.strip().lower()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _restore_original_or_raise(
+    path: Path,
+    original: bytes,
+    original_sha: str,
+    prior_exc: Exception,
+) -> None:
+    try:
+        _assert_single_link_regular_file(path, "rollback target")
+        sf.atomic_write_bytes(path, original)
+        if _sha256_file_descriptor(path) != original_sha:
+            raise OrchestratorGateError(
+                f"rollback verification failed for {path!s}; restored bytes "
+                "do not match the pre-mutation checksum"
+            )
+    except Exception as restore_exc:
+        raise OrchestratorGateError(
+            f"rollback failed after ship gate error {prior_exc!r}; "
+            f"{path!s} may be approved but uncommitted"
+        ) from restore_exc
+
+
+def _validate_review_envelope(envelope: dict[str, Any], repo_root: Path) -> Path:
+    job_id = envelope.get("job_id")
+    if not isinstance(job_id, str) or not _REVIEW_JOB_ID_RE.match(job_id):
+        raise OrchestratorGateError(
+            f"review envelope missing valid job_id: {job_id!r}"
+        )
+    raw_log = envelope.get("log_path")
+    if not isinstance(raw_log, str) or not raw_log.strip():
+        raise OrchestratorGateError("review envelope missing log_path")
+    log_path = Path(raw_log)
+    if log_path.is_absolute():
+        raise OrchestratorGateError(
+            f"review envelope log_path must be repo-relative, got {raw_log!r}"
+        )
+    expected_log = Path(".code-reviews") / f"{job_id}.log"
+    if log_path.as_posix() != expected_log.as_posix():
+        raise OrchestratorGateError(
+            f"review log_path {raw_log!r} does not match expected "
+            f"{expected_log.as_posix()!r}"
+        )
+    if any(part == ".." for part in log_path.parts):
+        raise OrchestratorGateError(
+            f"review log_path must not contain traversal: {raw_log!r}"
+        )
+    resolved = (repo_root / log_path).resolve(strict=False)
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise OrchestratorGateError(
+            f"review envelope log_path escapes repo root: {raw_log!r}"
+        ) from exc
+    try:
+        log_info = (repo_root / log_path).lstat()
+    except OSError as exc:
+        raise OrchestratorGateError(
+            f"review log_path does not exist: {raw_log!r}"
+        ) from exc
+    if stat.S_ISLNK(log_info.st_mode) or not stat.S_ISREG(log_info.st_mode):
+        raise OrchestratorGateError(
+            f"review log_path must be a regular non-symlink file: {raw_log!r}"
+        )
+    return resolved
+
+
+def _load_review_state(state_path: Path) -> dict[str, Any]:
+    if not state_path.is_file():
+        raise OrchestratorGateError(
+            f"review state file missing: {state_path!s}"
+        )
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    if not isinstance(state.get("primary_used"), str):
+        raise OrchestratorGateError("review state missing primary_used")
+    if not isinstance(state.get("fallback_used"), bool):
+        raise OrchestratorGateError("review state missing fallback_used")
+    return state
+
+
+def _validate_git_command(cmd: list[str]) -> None:
+    if not cmd or cmd[0] != "git":
+        raise OrchestratorGateError(
+            f"run_git_command only accepts git commands, got {cmd!r}"
+        )
+    if len(cmd) < 2 or cmd[1] not in _ALLOWED_GIT_SUBCOMMANDS:
+        raise OrchestratorGateError(
+            f"git subcommand must be one of {sorted(_ALLOWED_GIT_SUBCOMMANDS)}, "
+            f"got {cmd[1] if len(cmd) > 1 else None!r}"
+        )
+
+
+def _sha256_file_descriptor(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_commit_field(label: str, value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OrchestratorGateError(f"unsafe commit field {label}: empty")
+    if any(ch in value for ch in "\r\n"):
+        raise OrchestratorGateError(
+            f"unsafe commit field {label}: contains newline"
+        )
+    if any(ord(ch) < 32 for ch in value):
+        raise OrchestratorGateError(
+            f"unsafe commit field {label}: contains control character"
+        )
+    if re.match(r"^[A-Za-z0-9-]+:\s", value):
+        raise OrchestratorGateError(
+            f"unsafe commit field {label}: looks like a git trailer"
+        )
+    return value.strip()
+
+
+def _safe_trailer_line(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OrchestratorGateError("unsafe trailer line: empty")
+    if any(ch in value for ch in "\r\n"):
+        raise OrchestratorGateError("unsafe trailer line: contains newline")
+    if any(ord(ch) < 32 for ch in value):
+        raise OrchestratorGateError(
+            "unsafe trailer line: contains control character"
+        )
+    if not re.match(r"^[A-Za-z0-9-]+:\s.+$", value.strip()):
+        raise OrchestratorGateError(
+            f"unsafe trailer line: malformed trailer {value!r}"
+        )
+    return value.strip()
+
+
+def _safe_review_focus(value: str) -> str:
+    if not isinstance(value, str):
+        raise OrchestratorGateError("review focus must be a string")
+    focus = value.strip()
+    if not focus:
+        return ""
+    if len(focus) > MAX_REVIEW_FOCUS_LEN:
+        raise OrchestratorGateError(
+            f"review focus exceeds {MAX_REVIEW_FOCUS_LEN} characters"
+        )
+    if any(ch in focus for ch in "\r\n\x00"):
+        raise OrchestratorGateError("review focus contains unsafe control characters")
+    if any(ord(ch) < 32 for ch in focus):
+        raise OrchestratorGateError("review focus contains unsafe control characters")
+    if "../" in focus or "..\\" in focus:
+        raise OrchestratorGateError("review focus contains path traversal text")
+    return focus
+
+
+def _safe_review_files(files: list[str], repo_root: Path) -> list[str]:
+    if not isinstance(files, list) or not files:
+        raise OrchestratorGateError("review files must be a non-empty list")
+    return [_safe_review_file(value, repo_root) for value in files]
+
+
+def _safe_review_file(value: str, repo_root: Path) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OrchestratorGateError("review file must be a non-empty string")
+    if "," in value or any(ch in value for ch in "\r\n\x00"):
+        raise OrchestratorGateError(
+            f"review file contains unsafe characters: {value!r}"
+        )
+    if any(ord(ch) < 32 for ch in value):
+        raise OrchestratorGateError(
+            f"review file contains unsafe control character: {value!r}"
+        )
+    path = Path(value)
+    if path.is_absolute() or any(part == ".." for part in path.parts):
+        raise OrchestratorGateError(
+            f"review file must be repo-relative and contained: {value!r}"
+        )
+    return _repo_relative(repo_root / path, repo_root)
+
+
+def _safe_review_path(path: Path, repo_root: Path, label: str) -> str:
+    rel = _repo_relative(path, repo_root)
+    return _safe_review_file(rel, repo_root)
+
+
+def _validate_ship_lease_id(value: str) -> None:
+    _require_text("ship_lease_id", value)
+    if not _SHIP_LEASE_RE.match(value):
+        raise OrchestratorGateError(
+            "ship_lease_id must be 3-128 chars of letters, digits, dot, "
+            "underscore, or hyphen"
+        )
+
+
+def _assert_single_link_regular_file(path: Path, label: str) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise OrchestratorGateError(
+            f"{label} must be a regular file; cannot stat {path!s}"
+        ) from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise OrchestratorGateError(
+            f"{label} must be a regular file, not a symlink or special file: {path!s}"
+        )
+    if info.st_nlink != 1:
+        raise OrchestratorGateError(
+            f"{label} must not be hardlinked; link count is {info.st_nlink}: {path!s}"
+        )
+
+
+def _assert_executable_regular_file(path: Path, label: str) -> None:
+    _assert_single_link_regular_file(path, label)
+    if not os.access(path, os.X_OK):
+        raise OrchestratorGateError(f"{label} must be executable: {path!s}")

--- a/tests/test_invest_orchestrator_adapters.py
+++ b/tests/test_invest_orchestrator_adapters.py
@@ -1,0 +1,904 @@
+"""Tests for callable K2Bi orchestrator safety adapters."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+import fcntl
+import json
+import os
+from unittest.mock import patch
+from datetime import date
+from pathlib import Path
+
+from scripts.lib import invest_orchestrator_adapters as ioa
+from scripts.lib import invest_ship_strategy as iss
+from scripts.lib import invest_thesis as it
+from scripts.lib import strategy_frontmatter as sf
+from tests.test_invest_ship_strategy import _make_tmp_repo, _write_strategy
+from tests.test_invest_thesis import _make_default_input, _seed_vault
+
+
+def _verified_claim(**overrides):
+    data = {
+        "claim_id": "claim-1",
+        "claim_text": "Revenue grew 20 percent year over year.",
+        "claim_load_bearing": True,
+        "source_url": "https://example.com/source",
+        "source_excerpt": "The company reported revenue grew 20 percent year over year.",
+        "curated_framing": "The curated info set framed revenue growth as 20 percent.",
+        "operator_mark": "verified",
+        "operator_note": None,
+        "source_vendor": "SEC filing",
+        "spot_check_vendor": "Perplexity",
+    }
+    data.update(overrides)
+    return ioa.ThesisClaimDecision(**data)
+
+
+class ThesisGateAdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_vault = Path(tempfile.mkdtemp(prefix="ioa_thesis_"))
+        _seed_vault(self.tmp_vault)
+        self.thesis_input = _make_default_input()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp_vault, ignore_errors=True)
+
+    def test_missing_source_excerpt_refuses_before_generate(self):
+        calls = []
+
+        def fake_generate(*args, **kwargs):
+            calls.append((args, kwargs))
+            return it.ThesisResult(path=self.tmp_vault / "wiki/tickers/NVDA.md", written=True)
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.verify_and_generate_thesis(
+                self.thesis_input,
+                self.tmp_vault,
+                claim_decisions=[_verified_claim(source_excerpt="")],
+                generate_func=fake_generate,
+            )
+
+        self.assertIn("source_excerpt", str(cm.exception))
+        self.assertEqual(calls, [])
+
+    def test_vendor_must_differ_refuses_before_generate(self):
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.verify_and_generate_thesis(
+                self.thesis_input,
+                self.tmp_vault,
+                claim_decisions=[
+                    _verified_claim(source_vendor="Kimi DR", spot_check_vendor="Kimi DR")
+                ],
+                generate_func=lambda *args, **kwargs: self.fail("generate must not run"),
+            )
+
+        self.assertIn("vendor-must-differ", str(cm.exception))
+
+    def test_refused_claim_without_calx_framed_override_refuses(self):
+        claim = _verified_claim(
+            operator_mark="refused",
+            operator_note="The source does not support the curated claim.",
+        )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.verify_and_generate_thesis(
+                self.thesis_input,
+                self.tmp_vault,
+                claim_decisions=[claim],
+                operator_override_reason="The thesis can stand without this claim.",
+                calx_override_acknowledged=False,
+                generate_func=lambda *args, **kwargs: self.fail("generate must not run"),
+            )
+
+        self.assertIn("L-2026-04-30-001", str(cm.exception))
+
+    def test_full_t7_discipline_calls_generate_with_operator_override(self):
+        captured = {}
+
+        def fake_generate(thesis_input, vault_root, **kwargs):
+            captured["verification"] = thesis_input.verification
+            captured["vault_root"] = vault_root
+            captured["kwargs"] = kwargs
+            return it.ThesisResult(path=vault_root / "wiki/tickers/NVDA.md", written=True)
+
+        claim = _verified_claim(
+            operator_mark="refused",
+            operator_note="The primary source contradicts this claim, but it is advisory.",
+        )
+        result = ioa.verify_and_generate_thesis(
+            self.thesis_input,
+            self.tmp_vault,
+            claim_decisions=[claim],
+            operator_override_reason=(
+                "Override accepted after CALX L-2026-04-30-001 framing; "
+                "the refused claim is advisory and not load-bearing to conviction."
+            ),
+            calx_override_acknowledged=True,
+            generate_func=fake_generate,
+            now=date(2026, 4, 19),
+            refresh=True,
+            learning_stage="novice",
+        )
+
+        self.assertTrue(result.thesis_result.written)
+        self.assertEqual(captured["vault_root"], self.tmp_vault)
+        self.assertEqual(captured["kwargs"]["now"], date(2026, 4, 19))
+        self.assertTrue(captured["kwargs"]["refresh"])
+        self.assertEqual(captured["kwargs"]["learning_stage"], "novice")
+        verification = captured["verification"]
+        self.assertEqual(verification.status, "operator-override")
+        self.assertEqual(verification.claims[0].operator_check, "refused")
+        self.assertEqual(result.audit["claims"][0]["source_excerpt"], claim.source_excerpt)
+        self.assertEqual(result.audit["claims"][0]["source_vendor"], "SEC filing")
+
+    def test_generate_func_must_return_thesis_result(self):
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.verify_and_generate_thesis(
+                self.thesis_input,
+                self.tmp_vault,
+                claim_decisions=[_verified_claim()],
+                generate_func=lambda *args, **kwargs: None,
+            )
+
+        self.assertIn("ThesisResult", str(cm.exception))
+
+
+class StrategySpecWriterAdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = Path(tempfile.mkdtemp(prefix="ioa_strategy_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.repo, ignore_errors=True)
+
+    def _decision(self, **overrides) -> ioa.StrategySpecDecision:
+        data = {
+            "slug": "spy",
+            "symbol": "SPY",
+            "sigid": "2026-06-04-test-signal",
+            "risk_envelope_pct": "0.01",
+            "order": {
+                "ticker": "SPY",
+                "side": "buy",
+                "qty": 1,
+                "order_type": "LMT",
+                "limit_price": "500.00",
+                "stop_loss": "490.00",
+                "time_in_force": "DAY",
+            },
+            "forward_guidance_metrics": [
+                {
+                    "metric": "none",
+                    "locked_threshold_text": "No thresholded metric",
+                    "guide_source_text": "operator-pasted: no guide applies",
+                    "guide_range_text": "no quantitative guide",
+                    "sits_inside_guide": False,
+                }
+            ],
+            "forward_guidance_status": "pass",
+            "how_this_works": "Buy SPY only when the operator-approved thesis remains intact.",
+            "bucket_rules": ["Bucket 4 exits when thesis-breaking news lands."],
+            "entry_rules": ["Enter only after operator confirms the rule set."],
+            "stop_rules": ["Stop at 490.00."],
+            "target_rules": ["Review at 510.00 and 525.00."],
+            "hold_rules": ["Maximum hold is 30 trading days."],
+            "kill_rules": ["Kill if the thesis is invalidated."],
+            "accepted_gaps": ["No regime filter for this first paper trade."],
+        }
+        data.update(overrides)
+        return ioa.StrategySpecDecision(**data)
+
+    def test_writes_complete_strategy_spec_that_passes_ship_shape(self):
+        result = ioa.write_complete_strategy_spec(self._decision(), repo_root=self.repo)
+
+        self.assertEqual(result.path, self.repo / "wiki/strategies/strategy_spy.md")
+        content = result.path.read_bytes()
+        fm = sf.parse(content)
+        iss._validate_strategy_shape(result.path, fm, content)
+        self.assertEqual(fm["status"], "proposed")
+        self.assertIn(b"## How This Works", content)
+        self.assertIn(b"## Bucket Rules", content)
+        self.assertIn(b"## Accepted Gaps", content)
+        self.assertEqual(result.content_sha256, ioa.strategy_file_sha256(result.path))
+
+    def test_write_verification_uses_descriptor_digest(self):
+        with patch(
+            "scripts.lib.invest_orchestrator_adapters._sha256_file_descriptor",
+            return_value="0" * 64,
+        ) as digest:
+            with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                ioa.write_complete_strategy_spec(self._decision(), repo_root=self.repo)
+
+        self.assertTrue(digest.called)
+        self.assertIn("write verification", str(cm.exception).lower())
+
+    def test_rejects_empty_how_this_works(self):
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.write_complete_strategy_spec(
+                self._decision(how_this_works="   "),
+                repo_root=self.repo,
+            )
+
+        self.assertIn("How This Works", str(cm.exception))
+        self.assertFalse((self.repo / "wiki/strategies/strategy_spy.md").exists())
+
+
+class FullShipWrapperAdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo, self.parent_sha = _make_tmp_repo()
+        self.strategy_path = _write_strategy(self.repo, slug="spy")
+        review_script = self.repo / "scripts" / "review.sh"
+        review_script.parent.mkdir(parents=True, exist_ok=True)
+        review_script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        review_script.chmod(0o755)
+
+    def tearDown(self) -> None:
+        subprocess.run(["rm", "-rf", str(self.repo)], check=False)
+
+    def _approval(self, **overrides) -> ioa.FullShipApproval:
+        approved_at = overrides.pop("approved_at", "2026-06-04T04:00:00.123456+00:00")
+        ship_lease_id = overrides.pop("ship_lease_id", "lease-spy-20260604")
+        digest = ioa.strategy_file_sha256(self.strategy_path)
+        data = {
+            "final_approval_token": (
+                f"APPROVE_STRATEGY:spy:{digest}:{approved_at}:{ship_lease_id}"
+            ),
+            "approved_by": "Keith",
+            "approved_at": approved_at,
+            "ship_lease_id": ship_lease_id,
+        }
+        data.update(overrides)
+        return ioa.FullShipApproval(**data)
+
+    def _approve_handler(self, path: Path, **kwargs) -> iss.StrategyCommitHints:
+        text = path.read_text(encoding="utf-8").replace("status: proposed", "status: approved")
+        path.write_text(text, encoding="utf-8")
+        return iss.StrategyCommitHints(
+            file=str(path),
+            slug="spy",
+            transition="proposed -> approved",
+            commit_subject="feat(strategy): approve spy",
+            trailers=iss.build_trailers("strategy", "proposed -> approved", "spy"),
+            timestamp_field="approved_at",
+            timestamp_value="2026-06-04T04:00:00+00:00",
+            parent_commit_sha=self.parent_sha,
+        )
+
+    def test_missing_final_approval_token_fails_before_mutation(self):
+        git_calls = []
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(final_approval_token=""),
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: git_calls.append(cmd),
+            )
+
+        self.assertIn("final approval", str(cm.exception).lower())
+        self.assertIn("status: proposed", self.strategy_path.read_text(encoding="utf-8"))
+        self.assertEqual(git_calls, [])
+
+    def test_missing_external_ship_lease_fails_before_review(self):
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(ship_lease_id=""),
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: ioa.CommandResult(0, "", ""),
+            )
+
+        self.assertIn("ship_lease_id", str(cm.exception))
+
+    def test_failed_plan_review_restores_file_and_does_not_commit(self):
+        git_calls = []
+
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            return ioa.ReviewGateResult(
+                verdict="NEEDS-ATTENTION",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=".code-reviews/plan.log",
+            )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: (
+                    git_calls.append(cmd) or ioa.CommandResult(0, "", "")
+                ),
+            )
+
+        self.assertIn("plan review", str(cm.exception).lower())
+        self.assertIn("status: proposed", self.strategy_path.read_text(encoding="utf-8"))
+        self.assertEqual(git_calls[0][:2], ["git", "status"])
+
+    def test_failed_diff_review_restores_original_bytes_and_does_not_commit(self):
+        git_calls = []
+        original = self.strategy_path.read_bytes()
+        review_kinds = []
+
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            review_kinds.append(request.kind)
+            verdict = "APPROVE" if request.kind == "plan" else "NEEDS-ATTENTION"
+            return ioa.ReviewGateResult(
+                verdict=verdict,
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: (
+                    git_calls.append(cmd) or ioa.CommandResult(0, "", "")
+                ),
+            )
+
+        self.assertIn("diff review", str(cm.exception).lower())
+        self.assertEqual(review_kinds, ["plan", "diff"])
+        self.assertEqual(self.strategy_path.read_bytes(), original)
+        self.assertEqual(git_calls[0][:2], ["git", "status"])
+
+    def test_replayed_approval_token_refuses_after_file_content_changes(self):
+        approval = self._approval()
+        self.strategy_path.write_text(
+            self.strategy_path.read_text(encoding="utf-8")
+            + "\n## Extra Rule\n\nChanged after approval.\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=approval,
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+            )
+
+        self.assertIn("content hash", str(cm.exception).lower())
+
+    def test_naive_approval_timestamp_refuses_before_review(self):
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(approved_at="2026-06-04T12:00:00"),
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+            )
+
+        self.assertIn("timezone", str(cm.exception).lower())
+
+    def test_success_runs_plan_review_diff_review_helper_and_commit(self):
+        review_kinds = []
+        git_calls = []
+
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            review_kinds.append(request.kind)
+            return ioa.ReviewGateResult(
+                verdict="APPROVE",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        def git_runner(cmd, cwd):
+            git_calls.append(cmd)
+            return ioa.CommandResult(returncode=0, stdout="", stderr="")
+
+        result = ioa.run_full_ship(
+            self.strategy_path,
+            approval=self._approval(),
+            review_runner=review_runner,
+            approve_handler=self._approve_handler,
+            git_runner=git_runner,
+        )
+
+        self.assertEqual(result.slug, "spy")
+        self.assertEqual(review_kinds, ["plan", "diff"])
+        self.assertIn("status: approved", self.strategy_path.read_text(encoding="utf-8"))
+        self.assertEqual(git_calls[0][:2], ["git", "status"])
+        self.assertEqual(git_calls[1][:2], ["git", "add"])
+        self.assertEqual(git_calls[2][:2], ["git", "commit"])
+        self.assertIn("--only", git_calls[2])
+        self.assertIn("wiki/strategies/strategy_spy.md", git_calls[2])
+        self.assertIn("Co-Shipped-By: invest-ship", result.commit_message)
+        self.assertEqual(result.events[0]["event"], "ship_start")
+        self.assertEqual(result.events[-1]["event"], "commit_succeeded")
+
+    def test_dirty_unrelated_tracked_file_refuses_before_review(self):
+        note = self.repo / "notes.md"
+        note.write_text("clean\n", encoding="utf-8")
+        subprocess.run(["git", "add", "notes.md"], cwd=str(self.repo), check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add note", "-q"],
+            cwd=str(self.repo),
+            check=True,
+        )
+        note.write_text("dirty\n", encoding="utf-8")
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+            )
+
+        self.assertIn("clean-tree", str(cm.exception).lower())
+        self.assertIn("notes.md", str(cm.exception))
+
+    def test_restore_staged_failure_is_not_swallowed(self):
+        review_kinds = []
+
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            review_kinds.append(request.kind)
+            return ioa.ReviewGateResult(
+                verdict="APPROVE",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        def git_runner(cmd, cwd):
+            if cmd[:2] == ["git", "commit"]:
+                return ioa.CommandResult(returncode=1, stdout="", stderr="commit failed")
+            if cmd[:3] == ["git", "restore", "--staged"]:
+                return ioa.CommandResult(returncode=1, stdout="", stderr="restore failed")
+            return ioa.CommandResult(returncode=0, stdout="", stderr="")
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=self._approve_handler,
+                git_runner=git_runner,
+            )
+
+        self.assertIn("restore --staged", str(cm.exception))
+
+    def test_dirty_index_blocks_working_tree_restore_after_commit_failure(self):
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            return ioa.ReviewGateResult(
+                verdict="APPROVE",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        def git_runner(cmd, cwd):
+            if cmd[:2] == ["git", "commit"]:
+                return ioa.CommandResult(returncode=1, stdout="", stderr="commit failed")
+            if cmd[:3] == ["git", "restore", "--staged"]:
+                return ioa.CommandResult(returncode=1, stdout="", stderr="restore failed")
+            if cmd[:3] == ["git", "reset", "HEAD"]:
+                return ioa.CommandResult(returncode=0, stdout="", stderr="")
+            if cmd[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return ioa.CommandResult(returncode=1, stdout="", stderr="")
+            return ioa.CommandResult(returncode=0, stdout="", stderr="")
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=self._approve_handler,
+                git_runner=git_runner,
+            )
+
+        self.assertIn("index still contains", str(cm.exception).lower())
+        self.assertIn("status: proposed", self.strategy_path.read_text(encoding="utf-8"))
+
+    def test_diff_review_failure_attaches_rollback_result_and_clears_marker(self):
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            verdict = "APPROVE" if request.kind == "plan" else "NEEDS-ATTENTION"
+            return ioa.ReviewGateResult(
+                verdict=verdict,
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=self._approve_handler,
+            )
+
+        result = cm.exception.rollback_result
+        self.assertIsNotNone(result)
+        self.assertTrue(result.working_tree_restored)
+        self.assertTrue(result.marker_cleared)
+        self.assertFalse(Path(result.marker_path).exists())
+
+    def test_failed_rollback_leaves_marker_and_structured_result(self):
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            return ioa.ReviewGateResult(
+                verdict="APPROVE",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        def git_runner(cmd, cwd):
+            if cmd[:2] == ["git", "commit"]:
+                return ioa.CommandResult(returncode=1, stdout="", stderr="commit failed")
+            return ioa.CommandResult(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "scripts.lib.invest_orchestrator_adapters._restore_original_or_raise",
+            side_effect=ioa.OrchestratorGateError("restore failed"),
+        ):
+            with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                ioa.run_full_ship(
+                    self.strategy_path,
+                    approval=self._approval(),
+                    review_runner=review_runner,
+                    approve_handler=self._approve_handler,
+                    git_runner=git_runner,
+                )
+
+        result = cm.exception.rollback_result
+        self.assertIsNotNone(result)
+        self.assertFalse(result.working_tree_restored)
+        self.assertFalse(result.marker_cleared)
+        self.assertTrue(Path(result.marker_path).exists())
+
+    def test_incomplete_rollback_marker_refuses_before_review(self):
+        marker_path = ioa._rollback_marker_path_for(self.strategy_path, self.repo)
+        marker_path.parent.mkdir(parents=True, exist_ok=True)
+        marker_path.write_text(
+            json.dumps(
+                {
+                    "strategy_path": "wiki/strategies/strategy_spy.md",
+                    "original_sha256": "0" * 64,
+                    "phase": "working_tree_restore",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+            )
+
+        self.assertIn("incomplete rollback", str(cm.exception).lower())
+
+    def test_commit_message_rejects_log_path_with_newline(self):
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            return ioa.ReviewGateResult(
+                verdict="APPROVE",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=".code-reviews/x.log\nInjected-Trailer: yes",
+            )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: ioa.CommandResult(0, "", ""),
+            )
+
+        self.assertIn("unsafe commit field", str(cm.exception).lower())
+
+    def test_commit_message_rejects_unsafe_trailer_line(self):
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            return ioa.ReviewGateResult(
+                verdict="APPROVE",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        def bad_approve_handler(path: Path, **kwargs) -> iss.StrategyCommitHints:
+            hints = self._approve_handler(path, **kwargs)
+            return iss.StrategyCommitHints(
+                file=hints.file,
+                slug=hints.slug,
+                transition=hints.transition,
+                commit_subject=hints.commit_subject,
+                trailers=["Strategy-Transition: proposed -> approved\nInjected: yes"],
+                timestamp_field=hints.timestamp_field,
+                timestamp_value=hints.timestamp_value,
+                parent_commit_sha=hints.parent_commit_sha,
+            )
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=bad_approve_handler,
+                git_runner=lambda cmd, cwd: ioa.CommandResult(0, "", ""),
+            )
+
+        self.assertIn("unsafe trailer", str(cm.exception).lower())
+
+    def test_existing_strategy_lock_refuses_concurrent_ship(self):
+        lock_path = ioa._lock_path_for(self.strategy_path, self.repo)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                ioa.run_full_ship(
+                    self.strategy_path,
+                    approval=self._approval(),
+                    review_runner=lambda request: self.fail("review must not run"),
+                    approve_handler=self._approve_handler,
+                    git_runner=lambda cmd, cwd: ioa.CommandResult(0, "", ""),
+                )
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+        self.assertIn("already locked", str(cm.exception).lower())
+
+    def test_lock_path_is_outside_git_and_validates_containment(self):
+        lock_path = ioa._lock_path_for(self.strategy_path, self.repo)
+        self.assertNotIn(".git", lock_path.parts)
+        self.assertEqual(lock_path.parent, self.repo / ".k2bi-orchestrator" / "locks")
+        with patch(
+            "scripts.lib.invest_orchestrator_adapters._slug_from_strategy_path",
+            return_value="../spy",
+        ):
+            with self.assertRaises(ioa.OrchestratorGateError):
+                ioa._lock_path_for(self.strategy_path, self.repo)
+
+    def test_full_ship_refuses_symlink_strategy_before_review(self):
+        backup = self.strategy_path.with_name("strategy_spy_real.md")
+        backup.write_bytes(self.strategy_path.read_bytes())
+        self.strategy_path.unlink()
+        self.strategy_path.symlink_to(backup)
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: ioa.CommandResult(0, "", ""),
+            )
+
+        self.assertIn("regular file", str(cm.exception).lower())
+
+    def test_full_ship_refuses_hardlinked_strategy_before_review(self):
+        os.link(self.strategy_path, self.strategy_path.with_name("strategy_spy_copy.md"))
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=lambda request: self.fail("review must not run"),
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: ioa.CommandResult(0, "", ""),
+            )
+
+        self.assertIn("hardlink", str(cm.exception).lower())
+
+    def test_review_verdict_requires_strict_header(self):
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "review.log"
+            log.write_text("review text says APPROVE was seen before\n", encoding="utf-8")
+            self.assertEqual(ioa._extract_review_verdict(log), "UNKNOWN_VERDICT")
+            log.write_text("# kimi-for-coding review -- APPROVE\n", encoding="utf-8")
+            self.assertEqual(ioa._extract_review_verdict(log), "APPROVE")
+            log.write_text("# kimi-for-coding review -- NEEDS-ATTENTION\n", encoding="utf-8")
+            self.assertEqual(ioa._extract_review_verdict(log), "NEEDS-ATTENTION")
+            self.assertEqual(ioa._extract_review_verdict(Path(td) / "missing.log"), "LOG_MISSING")
+
+    def test_review_script_must_be_regular_executable_file(self):
+        review_script = self.repo / "scripts" / "review.sh"
+        review_script.unlink()
+        review_script.symlink_to(self.strategy_path)
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_review_with_script(
+                ioa.ReviewRequest(
+                    kind="diff",
+                    path=self.strategy_path,
+                    files=["wiki/strategies/strategy_spy.md"],
+                    focus="test",
+                )
+            )
+
+        self.assertIn("review script", str(cm.exception).lower())
+
+    def test_review_envelope_rejects_symlink_log_path(self):
+        job_id = "2026-06-04T14-00-00Z_abc123"
+        review_dir = self.repo / ".code-reviews"
+        review_dir.mkdir()
+        (review_dir / f"{job_id}.json").write_text(
+            json.dumps({"primary_used": "minimax", "fallback_used": False}),
+            encoding="utf-8",
+        )
+        (review_dir / "link.log").symlink_to(self.strategy_path)
+        with patch("scripts.lib.invest_orchestrator_adapters.subprocess.run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=["scripts/review.sh"],
+                returncode=0,
+                stdout=json.dumps(
+                    {"job_id": job_id, "log_path": ".code-reviews/link.log"}
+                ),
+                stderr="",
+            )
+            with patch("scripts.lib.invest_orchestrator_adapters._repo_root_for", return_value=self.repo):
+                with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                    ioa.run_review_with_script(
+                        ioa.ReviewRequest(
+                            kind="diff",
+                            path=self.strategy_path,
+                            files=["wiki/strategies/strategy_spy.md"],
+                            focus="test",
+                        )
+                    )
+
+        self.assertIn("review log_path", str(cm.exception))
+
+    def test_review_script_rejects_unsafe_file_list(self):
+        with patch("scripts.lib.invest_orchestrator_adapters.subprocess.run") as run:
+            with patch("scripts.lib.invest_orchestrator_adapters._repo_root_for", return_value=self.repo):
+                with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                    ioa.run_review_with_script(
+                        ioa.ReviewRequest(
+                            kind="diff",
+                            path=self.strategy_path,
+                            files=["wiki/strategies/strategy_spy.md,bad"],
+                            focus="test",
+                        )
+                    )
+
+        self.assertFalse(run.called)
+        self.assertIn("review file", str(cm.exception).lower())
+
+    def test_review_envelope_missing_job_id_refuses(self):
+        with patch("scripts.lib.invest_orchestrator_adapters.subprocess.run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=["scripts/review.sh"],
+                returncode=0,
+                stdout='{"job_id": null, "log_path": ".code-reviews/fake.log"}',
+                stderr="",
+            )
+            with patch("scripts.lib.invest_orchestrator_adapters._repo_root_for", return_value=self.repo):
+                with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                    ioa.run_review_with_script(
+                        ioa.ReviewRequest(
+                            kind="diff",
+                            path=self.strategy_path,
+                            files=["wiki/strategies/strategy_spy.md"],
+                            focus="test",
+                        )
+                    )
+
+        self.assertIn("review envelope", str(cm.exception).lower())
+
+    def test_review_script_timeout_refuses(self):
+        request = ioa.ReviewRequest(
+            kind="diff",
+            path=self.strategy_path,
+            files=["wiki/strategies/strategy_spy.md"],
+            focus="test",
+        )
+        with patch("scripts.lib.invest_orchestrator_adapters.subprocess.run") as run:
+            run.side_effect = subprocess.TimeoutExpired(
+                cmd=["scripts/review.sh"],
+                timeout=300,
+            )
+            with patch("scripts.lib.invest_orchestrator_adapters._repo_root_for", return_value=self.repo):
+                with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                    ioa.run_review_with_script(request)
+
+        self.assertIn("timed out", str(cm.exception).lower())
+
+    def test_review_script_rejects_unsafe_focus_before_spawn(self):
+        with patch("scripts.lib.invest_orchestrator_adapters.subprocess.run") as run:
+            with patch("scripts.lib.invest_orchestrator_adapters._repo_root_for", return_value=self.repo):
+                with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                    ioa.run_review_with_script(
+                        ioa.ReviewRequest(
+                            kind="diff",
+                            path=self.strategy_path,
+                            files=["wiki/strategies/strategy_spy.md"],
+                            focus="safe line\nInjected: yes",
+                        )
+                    )
+
+        self.assertFalse(run.called)
+        self.assertIn("review focus", str(cm.exception).lower())
+
+    def test_review_script_nonempty_stderr_refuses(self):
+        job_id = "2026-06-04T14-00-00Z_abc123"
+        review_dir = self.repo / ".code-reviews"
+        review_dir.mkdir()
+        (review_dir / f"{job_id}.log").write_text(
+            "# kimi-for-coding review -- APPROVE\n",
+            encoding="utf-8",
+        )
+        (review_dir / f"{job_id}.json").write_text(
+            json.dumps(
+                {
+                    "scope": "diff",
+                    "files": "wiki/strategies/strategy_spy.md",
+                    "focus": "test",
+                    "primary_used": "minimax",
+                    "fallback_used": False,
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch("scripts.lib.invest_orchestrator_adapters.subprocess.run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=["scripts/review.sh"],
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "job_id": job_id,
+                        "log_path": f".code-reviews/{job_id}.log",
+                    }
+                ),
+                stderr="unexpected warning",
+            )
+            with patch("scripts.lib.invest_orchestrator_adapters._repo_root_for", return_value=self.repo):
+                with self.assertRaises(ioa.OrchestratorGateError) as cm:
+                    ioa.run_review_with_script(
+                        ioa.ReviewRequest(
+                            kind="diff",
+                            path=self.strategy_path,
+                            files=["wiki/strategies/strategy_spy.md"],
+                            focus="test",
+                        )
+                    )
+
+        self.assertIn("stderr", str(cm.exception).lower())
+
+    def test_repo_root_probe_fails_closed_outside_git(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "wiki" / "strategies" / "strategy_spy.md"
+            path.parent.mkdir(parents=True)
+            path.write_text("x", encoding="utf-8")
+            with self.assertRaises(ioa.OrchestratorGateError):
+                ioa._repo_root_for(path)
+
+    def test_run_git_command_rejects_non_git_command(self):
+        with self.assertRaises(ioa.OrchestratorGateError):
+            ioa.run_git_command(["/bin/echo", "hello"], self.repo)
+
+    def test_subprocess_calls_decode_as_utf8_with_replacement(self):
+        with patch("scripts.lib.invest_orchestrator_adapters.subprocess.run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=["git", "status"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+            ioa.run_git_command(["git", "status"], self.repo)
+
+        self.assertEqual(run.call_args.kwargs["encoding"], "utf-8")
+        self.assertEqual(run.call_args.kwargs["errors"], "replace")
+
+    def test_run_git_checked_requires_command_result(self):
+        with self.assertRaises(ioa.OrchestratorGateError):
+            ioa._run_git_checked(lambda cmd, cwd: None, ["git", "status"], self.repo)
+
+    def test_repo_relative_refuses_path_outside_repo(self):
+        with self.assertRaises(ioa.OrchestratorGateError):
+            ioa._repo_relative(Path("/tmp/outside_strategy.md"), self.repo)


### PR DESCRIPTION
## Scope

Adds callable K2Bi adapter functions for the K2B orchestrator handoff:

- `verify_and_generate_thesis` gates thesis generation with T7 claim evidence checks before calling the existing thesis helper.
- `write_complete_strategy_spec` authors complete proposed strategy files from typed T10/T11 decisions and verifies post-write digest.
- `run_full_ship` wraps the full ship path with plan review, explicit final approval token, diff review, git staging, commit, rollback handling, and Kimi primary review enforcement.

This is expose-as-callable adapter work only. It does not modify engine execution, broker connectors, validators, runtime deployment, or `.killed` handling.

## Round 7 disposition

Attached in `.code-reviews/orchestrator-adapters-round-7-response.md`.

K2B PM ruling reframes this adapter as upstream of the engine gate. The engine only loads `status: approved` strategies with traceable `approved_commit_sha`, so the remaining review discussion is correctness and recoverability, not capital leak.

Final Kimi review:

- job_id: `2026-06-06T07-35-03Z_2459b9`
- `primary_used=minimax`, `fallback_used=false`
- verdict: `NEEDS-ATTENTION`

Per Round 7 hard stop, this PR is raised despite the verdict. Remaining reviewer findings return to Keith's K2Bi PM review of this PR.

## Deferred by design

Approval-token replay protection belongs in the orchestrator protocol handoff #2, where consumed-token or nonce state can be owned centrally. This adapter binds the approval token to slug, content hash, UTC `approved_at`, and `ship_lease_id`, but it does not implement a server-side nonce store.

## Verification

- `python3 -m pytest tests/test_invest_orchestrator_adapters.py -q` -> 40 passed
- `python3 -m pytest tests/test_invest_orchestrator_adapters.py tests/test_invest_thesis.py tests/test_invest_coach.py tests/test_invest_ship_strategy.py -q` -> 282 passed
- `python3 scripts/lib/deploy_config.py preflight` -> exit 0
- `python3 -m py_compile scripts/lib/invest_orchestrator_adapters.py` -> exit 0
- `git diff --check` -> exit 0
- `python3 -m pytest tests/ -q` -> 1808 passed, 1 skipped, 2 warnings, 53 subtests passed

## Merge boundary

Do not merge from this branch in Codex. This PR returns to Keith's K2Bi PM safety review.
