### PR TITLE
calibrate orchestrator-adapter internal plan-review focus for single-operator paper MVP

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -2457,3 +2457,21 @@ distilled-rule: "When verification gates include an operator-override escape hat
 **Follow-ups:** Two `/request` items filed: make `scripts/review.sh` tolerate pre-existing unrelated untracked directories, and investigate Kimi reviewer unparseable / `NEEDS-ATTENTION` output on this iteration.
 
 **Key decisions:** Piece B Tier 1 engine snapshots remain deferred. PID-based stale-lock recovery replaced the initial mtime fallback; `is_ssh_token()` closes PATH-explicit `/usr/bin/ssh`; `past_dashdash` closes the `ssh -- hostinger` bypass.
+
+## 2026-06-09 -- orchestrator plan-review focus calibrated for single-operator paper MVP
+
+**Commit:** `f92cfb1` fix(orchestrator): calibrate plan-review focus for single-operator paper MVP
+
+**PR:** https://github.com/kcstudio/K2Bi/pull/11 (open, not yet merged)
+
+**What shipped:** Calibrated the two internal Kimi plan-review FOCUS PROMPTS in `scripts/lib/invest_orchestrator_adapters.py` so a single-operator PAPER-trading proposal is no longer reviewed as production infrastructure. `_make_limits_plan_review_request` and `_strategy_plan_review_focus()` now carry the deployment context (atomic-write + dual-sha + rollback + strategy-ship gate are adapter-enforced, so config drift / stale-patch / atomic-write / rollback / strategy-to-ticker coupling are OUT OF SCOPE) and an explicit IN-SCOPE/OUT-OF-SCOPE boundary. The strategy focus keeps every existing quality check (look-ahead, unrealistic orders, regime mismatch, weak How-This-Works, safety-gate bypass). The gate logic (`_require_review_approved`) and both diff-review focuses are unchanged. Added `PlanReviewFocusCalibrationTests` (2 tests) locking the calibration in. Source: `K2Bi-Vault/proposals/2026-06-09_proposal_calibrate-orchestrator-review-focus.md`.
+
+**Codex review:** APPROVE, no material findings (job `2026-06-09T08-44-34Z_0d187c`). Confirmed the gate still fails closed on non-APPROVE, diff-review focuses unchanged, both new focus strings retain their defect checks, strings under MAX_REVIEW_FOCUS_LEN with no control chars.
+
+**Tests:** `tests/test_invest_orchestrator_adapters.py` -- 64 passed (incl. 2 new calibration tests).
+
+**Feature status change:** none (K2Bi vault has no wiki/concepts roadmap; this is an infrastructure calibration of already-shipped adapters).
+
+**Follow-ups:** After PR #11 merges to main, /sync the `scripts` category to the VPS, then re-run K2B's parked A4 (`retry-limits 2026-06-09-001` -> re-dispatch `k2bi-apply-limits` -> verify -> terminal_limits_applied, CDNS whitelisted) and A3 (address CDNS strategy findings -> `retry-ship 2026-06-07-001` -> terminal_shipped).
+
+**Key decisions:** Calibrated the focus PROMPT, not the gate logic or severity threshold -- smallest, most auditable, most reversible lever for a capital path. Shipped as a PR (not direct-to-main) per Keith's explicit request; branched from origin/main to keep the PR free of the unrelated unpushed build-plan docs commit (6d648f7).

--- a/scripts/lib/invest_orchestrator_adapters.py
+++ b/scripts/lib/invest_orchestrator_adapters.py
@@ -836,8 +836,24 @@ def _make_limits_plan_review_request(
         path=proposal_path,
         files=[proposal_rel],
         focus=(
-            "Review this operator-approved limits proposal for safety impact, "
-            "stale patch risk, validator weakening, and config gate bypass."
+            "Deployment context: K2Bi is a SINGLE-OPERATOR PAPER-TRADING system. "
+            "This limits proposal is applied by the apply_approved_limits adapter, "
+            "which atomically writes and sha-verifies both files, binds a dual-sha "
+            "operator-approval token to the config bytes, and rolls back on any "
+            "failed gate -- so config drift, stale-patch detection, atomic write, "
+            "and rollback are ALREADY enforced by the adapter and are OUT OF SCOPE. "
+            "A whitelisted ticker is tradeable ONLY by a strategy that itself "
+            "passed the separate strategy-ship gate, so strategy-to-ticker coupling "
+            "is OUT OF SCOPE here. Review ONLY for IN-SCOPE proposal defects: the "
+            "`## YAML Patch` not matching the stated `## Change` before/after; a "
+            "wrong rule / change_type / ticker / field; a patch that WEAKENS a "
+            "validator (loosens a threshold, removes a guard, widens a limit); "
+            "malformed frontmatter; or a real config-gate bypass. Do NOT raise "
+            "production-infrastructure or process concerns (CI, two-person rule, "
+            "per-ticker validator calibration, emergency-removal tooling, "
+            "/invest-ship internals, feature flags, canary/shadow mode) -- those "
+            "are out of scope for a single-operator paper limits proposal. Return "
+            "NEEDS-ATTENTION ONLY for an in-scope defect; otherwise APPROVE."
         ),
         required_primary=required_primary,
     )
@@ -2018,9 +2034,15 @@ def _build_strategy_commit_message(
 
 def _strategy_plan_review_focus() -> str:
     return (
-        "Review this proposed strategy spec for look-ahead bias, unrealistic "
-        "order assumptions, regime_filter mismatch, weak How This Works clarity, "
-        "and any K2Bi safety gate bypass."
+        "Deployment context: K2Bi is a SINGLE-OPERATOR PAPER-TRADING system; the "
+        "run_full_ship adapter owns atomic write, sha-binding, commit, and "
+        "rollback (OUT OF SCOPE). Review this proposed strategy spec for IN-SCOPE "
+        "defects ONLY: look-ahead bias, unrealistic order assumptions, "
+        "regime_filter mismatch, weak How-This-Works clarity, and any real K2Bi "
+        "safety-gate bypass. Do NOT raise production-infrastructure or process "
+        "concerns (CI, two-person rule, deployment tooling, monitoring/alerting, "
+        "per-ticker infra) -- out of scope for a single-operator paper strategy. "
+        "NEEDS-ATTENTION ONLY for an in-scope strategy defect."
     )
 
 

--- a/tests/test_invest_orchestrator_adapters.py
+++ b/tests/test_invest_orchestrator_adapters.py
@@ -1568,3 +1568,38 @@ class FullShipWrapperAdapterTests(unittest.TestCase):
     def test_repo_relative_refuses_path_outside_repo(self):
         with self.assertRaises(ioa.OrchestratorGateError):
             ioa._repo_relative(Path("/tmp/outside_strategy.md"), self.repo)
+
+
+class PlanReviewFocusCalibrationTests(unittest.TestCase):
+    """Lock the single-operator-paper calibration into both plan-review focuses.
+
+    The orchestrator plan reviews block legitimate, minimal proposals when their
+    focus prompt lets the reviewer treat a single-operator PAPER proposal as
+    production infrastructure. These asserts are a cheap regression so the
+    calibration (deployment context + an explicit out-of-scope boundary) cannot
+    silently revert. They do NOT assert the gate is weakened: the genuine
+    strategy-quality checks must stay present.
+    """
+
+    DEPLOYMENT_CONTEXT_MARKER = "SINGLE-OPERATOR PAPER-TRADING"
+    OUT_OF_SCOPE_MARKER = "OUT OF SCOPE"
+
+    def test_limits_plan_review_focus_carries_context_and_scope_boundary(self):
+        focus = ioa._make_limits_plan_review_request(
+            Path("review/strategy-approvals/limits_x.md"),
+            proposal_rel="review/strategy-approvals/limits_x.md",
+            required_primary="minimax",
+        ).focus
+        self.assertIn(self.DEPLOYMENT_CONTEXT_MARKER, focus)
+        self.assertIn(self.OUT_OF_SCOPE_MARKER, focus)
+        # Calibration keeps the real defect checks, does not weaken the gate.
+        self.assertIn("WEAKENS a validator", focus)
+        self.assertLessEqual(len(focus), ioa.MAX_REVIEW_FOCUS_LEN)
+
+    def test_strategy_plan_review_focus_carries_context_and_scope_boundary(self):
+        focus = ioa._strategy_plan_review_focus()
+        self.assertIn(self.DEPLOYMENT_CONTEXT_MARKER, focus)
+        self.assertIn(self.OUT_OF_SCOPE_MARKER, focus)
+        # Existing strategy-quality checks must survive the calibration.
+        self.assertIn("look-ahead", focus)
+        self.assertLessEqual(len(focus), ioa.MAX_REVIEW_FOCUS_LEN)


### PR DESCRIPTION
The `run_full_ship` and `apply_approved_limits` internal plan reviews block legitimate, minimal proposals (CDNS whitelist add; CDNS strategy) with engine-architecture / production-process findings -- several false premises (the reviewer sees only the proposal, not the adapter's atomic-write + dual-sha + rollback, nor the strategy-ship gate). This scopes the two plan-review focus prompts to in-scope proposal defects only, adding the single-operator paper deployment context + an explicit OUT-OF-SCOPE list, while keeping every genuine defect check and the NEEDS-ATTENTION brake. Evidenced by the K2B orchestrator A3/A4 live MVP, where both positive sends rolled back clean on these reviews.

## What changed

- `_make_limits_plan_review_request` focus (limits plan review): adds the single-operator paper deployment context, marks adapter guarantees (atomic write, dual-sha, rollback, stale-patch/drift detection) and strategy-to-ticker coupling OUT OF SCOPE, and lists IN-SCOPE defects (patch != stated change, wrong rule/change_type/ticker/field, validator weakening, malformed frontmatter, config-gate bypass).
- `_strategy_plan_review_focus()` (run_full_ship plan review): prepends the same deployment context + scope boundary while KEEPING the existing strategy-quality checks (look-ahead bias, unrealistic orders, regime_filter mismatch, weak How-This-Works clarity, safety-gate bypass).
- New `PlanReviewFocusCalibrationTests` asserting both focus strings carry the deployment context + an OUT-OF-SCOPE marker, keep their defect checks, and stay within `MAX_REVIEW_FOCUS_LEN`.

## What did NOT change (this calibrates, it does not weaken)

- `_require_review_approved` still raises on NEEDS-ATTENTION (the capital-safety brake).
- Both diff-review focuses are untouched.
- The review still blocks NEEDS-ATTENTION on real defects (validator weakening, gate bypass, patch != stated change, look-ahead, etc.).

## Review

Cross-model adversarial review (Codex, Checkpoint 2) on the diff: verdict APPROVE, no material findings. Confirmed the gate still fails closed on non-APPROVE, diff-review focuses unchanged, both new focus strings retain their defect checks, strings under the length cap with no control chars. Full `tests/test_invest_orchestrator_adapters.py` suite: 64 tests pass (including the 2 new calibration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)