### PR TITLE
refactor(orchestrator): make limits-apply plan review advisory (Change 6)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -2475,3 +2475,19 @@ distilled-rule: "When verification gates include an operator-override escape hat
 **Follow-ups:** After PR #11 merges to main, /sync the `scripts` category to the VPS, then re-run K2B's parked A4 (`retry-limits 2026-06-09-001` -> re-dispatch `k2bi-apply-limits` -> verify -> terminal_limits_applied, CDNS whitelisted) and A3 (address CDNS strategy findings -> `retry-ship 2026-06-07-001` -> terminal_shipped).
 
 **Key decisions:** Calibrated the focus PROMPT, not the gate logic or severity threshold -- smallest, most auditable, most reversible lever for a capital path. Shipped as a PR (not direct-to-main) per Keith's explicit request; branched from origin/main to keep the PR free of the unrelated unpushed build-plan docs commit (6d648f7).
+
+## 2026-06-10 -- limits-apply plan review made advisory (Change 6)
+
+**Commit:** `61d26ab` refactor(orchestrator): make limits-apply plan review advisory (Change 6)
+
+**What shipped:** `apply_approved_limits`'s internal PLAN review went from a blocking gate (`_require_review_approved`) to ADVISORY, mirroring Change 5's diff-review downgrade (#13). The plan review still runs and now records a `plan_review_advisory` event (verdict + log_path); a NEEDS-ATTENTION verdict no longer raises. Motivation (Round 4 addendum): the plan review is non-deterministic as a hard gate -- on the identical operator-approved, byte-verified CDNS proposal it APPROVE'd twice, then emitted a NEEDS-ATTENTION header while its body concluded "No findings, verdict should be APPROVE", blocking a clean change. The limits apply is already protected by 8 deterministic/human gates (operator approval, dual-sha token, kill-switch, clean-tree, scope guard, deterministic byte-checks, atomic write + rollback, independent K2B inspector); the LLM plan review was a redundant 9th. Left unchanged: byte-checks, `handle_approve_limits`, commit/rollback, and the `run_full_ship` strategy reviews (still blocking).
+
+**Codex review:** NEEDS-ATTENTION, 1 HIGH (job `2026-06-10T08-01-12Z_97c52b`). HIGH: "advisory plan review leaves Change-vs-YAML-Patch semantic mismatches as an accepted path." Valid observation, DEFERRED (not a Change-6 defect): it is the exact redundant-LLM-review trade-off Keith decided in the Round 4 addendum -- the operator approves the exact proposal bytes (which contain the real YAML Patch, not just the prose) and the byte-check binds committed config to that patch. The recommended fix (a deterministic `## Change`-vs-`## YAML Patch` validator) is a new hardening feature touching `handle_approve_limits`, which this change is instructed to leave unchanged. Filed as a follow-up.
+
+**Tests:** reworked `test_change5_needs_attention_plan_review_still_blocks_and_rolls_back` -> `test_change6_needs_attention_plan_review_is_advisory_byte_check_binds` (NEEDS-ATTENTION plan now COMMITS + advisory event; forced post-handler byte mismatch STILL raises + rolls back) and `test_rejects_plan_review_fallback_or_wrong_primary` -> `test_plan_review_fallback_or_wrong_primary_is_advisory_and_commits`. Kept the byte-mismatch + diff-advisory tests. 68 passed (adapter suite); 141 passed with `test_invest_ship_strategy`. Verified the reworked tests fail under the pre-Change-6 blocking code (non-tautological).
+
+**Feature status change:** none (K2Bi vault has no wiki/concepts roadmap; infrastructure calibration of already-shipped adapters).
+
+**Follow-ups:** Deferred Codex HIGH -- add a deterministic `## Change`-prose vs `## YAML-Patch` semantic-consistency validator to `apply_approved_limits`. After merge, both limits reviews (plan + diff) are advisory live; the deterministic byte-check is the binding mechanical gate.
+
+**Key decisions:** Scoped strictly to the limits apply per the Round 4 addendum -- the strategy/`run_full_ship` reviews stay blocking. Shipped as a PR (not direct-to-main) per Keith's pattern; the untracked CDNS proposal was left alone.

--- a/scripts/lib/invest_orchestrator_adapters.py
+++ b/scripts/lib/invest_orchestrator_adapters.py
@@ -558,7 +558,16 @@ def apply_approved_limits(
             expected_files=[proposal_rel],
         )
         events.append(_review_event("plan_review_completed", plan_review))
-        _require_review_approved(plan_review, "plan review", required_primary)
+        # ADVISORY ONLY (2026-06-10): the limits-apply plan review is non-deterministic on a clean,
+        # operator-approved, byte-verified proposal (it concluded "No findings, verdict should be
+        # APPROVE" yet emitted a NEEDS-ATTENTION header and blocked; it had APPROVE'd the identical
+        # proposal twice before). The operator's explicit approval + the dual-sha token + the
+        # deterministic byte-checks are the real safety; the LLM plan review is advisory input.
+        events.append({
+            "event": "plan_review_advisory",
+            "verdict": plan_review.verdict,
+            "log_path": plan_review.log_path,
+        })
 
         originals = {
             proposal_rel: (proposal_path, original_proposal, original_shas[proposal_rel]),

--- a/tests/test_invest_orchestrator_adapters.py
+++ b/tests/test_invest_orchestrator_adapters.py
@@ -589,16 +589,64 @@ class ApplyApprovedLimitsAdapterTests(unittest.TestCase):
         self.assertEqual(advisory[0]["verdict"], "NEEDS-ATTENTION")
         self.assertEqual(advisory[0]["log_path"], ".code-reviews/diff.log")
 
-    def test_change5_needs_attention_plan_review_still_blocks_and_rolls_back(self):
-        # Part (a) of the Change 5 proof: the PLAN gate stays intact. A
-        # NEEDS-ATTENTION plan verdict refuses before the handler mutates anything,
-        # the diff review never runs, and nothing commits.
+    def test_change6_needs_attention_plan_review_is_advisory_byte_check_binds(self):
+        # Change 6 (2026-06-10): the limits-apply PLAN review is now ADVISORY too
+        # (like the diff review in Change 5). A NEEDS-ATTENTION plan verdict must be
+        # recorded for audit but must NOT block -- the apply still commits. The
+        # deterministic post-handler byte-check is now the binding mechanical gate.
+        #
+        # Part (b) runs FIRST: it rolls back cleanly, leaving the tree pristine for
+        # Part (a). Even with the plan review advisory, a handler that mutates config
+        # bytes off the approved patch STILL raises + rolls back before the diff
+        # review runs -- proving the byte-check, not the LLM review, is the gate.
         original_proposal = self.proposal_path.read_bytes()
         original_config = self.config_path.read_bytes()
+        byte_review_kinds: list[str] = []
+
+        def needs_attention_review(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            byte_review_kinds.append(request.kind)
+            return ioa.ReviewGateResult(
+                verdict="NEEDS-ATTENTION",
+                primary_used="minimax",
+                fallback_used=False,
+                log_path=f".code-reviews/{request.kind}.log",
+            )
+
+        def bad_handler(path: Path, **kwargs) -> iss.LimitsCommitHints:
+            hints = self._approve_handler(path, **kwargs)
+            self.config_path.write_text(
+                self.config_path.read_text(encoding="utf-8") + "# unexpected\n",
+                encoding="utf-8",
+            )
+            return hints
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.apply_approved_limits(
+                self.proposal_path,
+                approval=self._limits_approval(),
+                review_runner=needs_attention_review,
+                approve_handler=bad_handler,
+                git_runner=self._fake_success_git(),
+                config_path=self.config_path,
+                now_utc=self.now_utc,
+            )
+
+        # The plan review did NOT block (advisory) -- execution proceeded into the
+        # handler; the byte-check is what raised, before the diff review ever ran.
+        self.assertIn("config bytes", str(cm.exception).lower())
+        self.assertEqual(byte_review_kinds, ["plan"])
+        self.assertIsNotNone(cm.exception.rollback_result)
+        self.assertTrue(cm.exception.rollback_result.working_tree_restored)
+        self.assertEqual(self.proposal_path.read_bytes(), original_proposal)
+        self.assertEqual(self.config_path.read_bytes(), original_config)
+
+        # Part (a): with the rollback complete the tree is pristine again. A clean
+        # apply whose PLAN review returns NEEDS-ATTENTION now COMMITS, recording the
+        # verdict as an advisory event rather than blocking.
         review_kinds: list[str] = []
         git_calls: list[list[str]] = []
 
-        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+        def commit_review(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
             review_kinds.append(request.kind)
             return ioa.ReviewGateResult(
                 verdict="NEEDS-ATTENTION",
@@ -607,22 +655,28 @@ class ApplyApprovedLimitsAdapterTests(unittest.TestCase):
                 log_path=f".code-reviews/{request.kind}.log",
             )
 
-        with self.assertRaises(ioa.OrchestratorGateError) as cm:
-            ioa.apply_approved_limits(
-                self.proposal_path,
-                approval=self._limits_approval(),
-                review_runner=review_runner,
-                approve_handler=self._approve_handler,
-                git_runner=self._fake_success_git(git_calls),
-                config_path=self.config_path,
-                now_utc=self.now_utc,
-            )
+        result = ioa.apply_approved_limits(
+            self.proposal_path,
+            approval=self._limits_approval(),
+            review_runner=commit_review,
+            approve_handler=self._approve_handler,
+            git_runner=self._fake_success_git(git_calls),
+            config_path=self.config_path,
+            now_utc=self.now_utc,
+        )
 
-        self.assertIn("plan review", str(cm.exception).lower())
-        self.assertEqual(review_kinds, ["plan"])  # plan refused before the diff review
-        self.assertFalse(any(cmd[:2] == ["git", "commit"] for cmd in git_calls))
-        self.assertEqual(self.proposal_path.read_bytes(), original_proposal)
-        self.assertEqual(self.config_path.read_bytes(), original_config)
+        # The change LANDED despite a NEEDS-ATTENTION plan verdict: both reviews ran,
+        # the apply committed, and the files carry the approved change.
+        self.assertEqual(review_kinds, ["plan", "diff"])
+        self.assertEqual(result.plan_review.verdict, "NEEDS-ATTENTION")
+        self.assertIn("status: approved", self.proposal_path.read_text(encoding="utf-8"))
+        self.assertIn("max_trade_risk_pct: 0.02", self.config_path.read_text(encoding="utf-8"))
+        self.assertTrue(any(cmd[:2] == ["git", "commit"] for cmd in git_calls))
+        # The advisory plan verdict is recorded in the event log for audit.
+        advisory = [e for e in result.events if e.get("event") == "plan_review_advisory"]
+        self.assertEqual(len(advisory), 1)
+        self.assertEqual(advisory[0]["verdict"], "NEEDS-ATTENTION")
+        self.assertEqual(advisory[0]["log_path"], ".code-reviews/plan.log")
 
     def test_change5_post_handler_byte_mismatch_still_blocks_despite_advisory_diff(self):
         # Part (b) of the Change 5 proof: the deterministic byte-check is the real
@@ -795,34 +849,44 @@ class ApplyApprovedLimitsAdapterTests(unittest.TestCase):
         self.assertIn("unsafe commit field", str(cm.exception).lower())
         self.assertIn("status: proposed", self.proposal_path.read_text(encoding="utf-8"))
 
-    def test_rejects_plan_review_fallback_or_wrong_primary(self):
-        # The PLAN review stays blocking (Change 5 only downgraded the diff review),
-        # so a fallback-used or wrong-primary plan verdict must still refuse before
-        # any mutation. The diff review's primary/fallback is no longer enforced.
+    def test_plan_review_fallback_or_wrong_primary_is_advisory_and_commits(self):
+        # Change 6 (2026-06-10): BOTH limits reviews are now advisory, so neither the
+        # plan nor the diff review's primary_used / fallback_used is enforced. A
+        # fallback-used or wrong-primary verdict that previously refused now records an
+        # advisory event and the apply commits. The operator token + dual-sha binding +
+        # deterministic byte-checks are the real safety, not the LLM review's provenance.
         cases = [
-            ("minimax", True, "fallback"),
-            ("codex", False, "primary_used"),
+            ("minimax", True),
+            ("codex", False),
         ]
-        for primary_used, fallback_used, expected in cases:
+        for primary_used, fallback_used in cases:
             with self.subTest(primary_used=primary_used, fallback_used=fallback_used):
                 self.tearDown()
                 self.setUp()
+                review_kinds: list[str] = []
+                git_calls: list[list[str]] = []
 
                 def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
-                    self.assertEqual(request.kind, "plan")  # diff review must never run
-                    return ioa.ReviewGateResult("APPROVE", primary_used, fallback_used, ".code-reviews/plan.log")
-
-                with self.assertRaises(ioa.OrchestratorGateError) as cm:
-                    ioa.apply_approved_limits(
-                        self.proposal_path,
-                        approval=self._limits_approval(),
-                        review_runner=review_runner,
-                        approve_handler=self._approve_handler,
-                        config_path=self.config_path,
-                        now_utc=self.now_utc,
+                    review_kinds.append(request.kind)
+                    return ioa.ReviewGateResult(
+                        "APPROVE", primary_used, fallback_used, f".code-reviews/{request.kind}.log"
                     )
-                self.assertIn(expected, str(cm.exception))
-                self.assertIn("status: proposed", self.proposal_path.read_text(encoding="utf-8"))
+
+                result = ioa.apply_approved_limits(
+                    self.proposal_path,
+                    approval=self._limits_approval(),
+                    review_runner=review_runner,
+                    approve_handler=self._approve_handler,
+                    git_runner=self._fake_success_git(git_calls),
+                    config_path=self.config_path,
+                    now_utc=self.now_utc,
+                )
+
+                self.assertEqual(review_kinds, ["plan", "diff"])
+                self.assertTrue(any(cmd[:2] == ["git", "commit"] for cmd in git_calls))
+                self.assertIn("status: approved", self.proposal_path.read_text(encoding="utf-8"))
+                advisory = [e for e in result.events if e.get("event") == "plan_review_advisory"]
+                self.assertEqual(len(advisory), 1)
 
     def test_handler_receives_approval_timestamp(self):
         approval = self._limits_approval(approved_at="2026-06-08T08:00:34.000000+00:00")


### PR DESCRIPTION
## Change 6 -- limits-apply plan review becomes advisory

`apply_approved_limits`'s internal PLAN review is downgraded from a blocking gate (`_require_review_approved`) to **advisory**, consistent with Change 5's diff-review downgrade ([#13](https://github.com/kcstudio/K2Bi/pull/13)). The plan review still runs and records a `plan_review_advisory` event (verdict + log_path); a NEEDS-ATTENTION verdict no longer raises.

### Why (Round 4 addendum, 2026-06-10)
The limits-apply plan review is **non-deterministic as a hard gate**. On the identical operator-approved, byte-verified CDNS proposal it APPROVE'd twice, then on the next run emitted a NEEDS-ATTENTION *header* while its own body concluded "The proposal is clean... No in-scope defect found... Verdict should be APPROVE" plus the literal line "_No findings._" -- so `_extract_review_verdict` parsed NEEDS-ATTENTION and the gate blocked a clean change.

The limits apply is already protected by **8 deterministic / human gates** with no LLM in them: operator approval of the exact proposal, dual-sha token, kill-switch read, clean-tree preflight, scope guard, deterministic byte-checks, atomic write + rollback, and the independent K2B inspector. The LLM plan review was a redundant 9th, non-deterministic opinion.

### Unchanged (per spec)
The deterministic byte-checks (now the binding mechanical gate), `handle_approve_limits`, the commit/rollback, and the `run_full_ship` **strategy** plan + diff reviews -- those stay blocking.

### Tests
- Reworked `test_change5_needs_attention_plan_review_still_blocks_and_rolls_back` -> `test_change6_needs_attention_plan_review_is_advisory_byte_check_binds`: proves a NEEDS-ATTENTION plan review now **commits** (advisory event recorded), while a forced post-handler byte mismatch **still raises + rolls back** (the byte-check is now the binding gate).
- Reworked `test_rejects_plan_review_fallback_or_wrong_primary` -> `test_plan_review_fallback_or_wrong_primary_is_advisory_and_commits`: both limits reviews are advisory, so `primary_used`/`fallback_used` is no longer enforced.
- Kept the byte-mismatch and diff-advisory tests.
- **68 passed** (adapter suite); **141 passed** with `test_invest_ship_strategy`. The reworked tests were verified to **fail** under the pre-Change-6 blocking code (non-tautological).

### Cross-model review
Codex (job `2026-06-10T08-01-12Z_97c52b`): NEEDS-ATTENTION, 1 HIGH -- *"advisory plan review leaves Change-vs-YAML-Patch semantic mismatches as an accepted path."* **Disposition: deferred, not a Change-6 defect.** It is the exact redundant-LLM-review trade-off decided in the Round 4 addendum -- the operator approves the *exact proposal bytes* (which contain the real YAML Patch, not just the `## Change` prose) and the byte-check binds committed config to that patch. The recommended fix (a deterministic `## Change`-vs-`## YAML Patch` validator) is a new hardening feature touching `handle_approve_limits`, which this change is instructed to leave unchanged. Filed as a follow-up.

Source: `K2Bi-Vault/proposals/2026-06-09_proposal_calibrate-orchestrator-review-focus.md` (Change 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)