### PR TITLE
feat(ship): deterministic strategy_spec_integrity preflight before AI plan review

### DIFF
--- a/scripts/lib/invest_orchestrator_adapters.py
+++ b/scripts/lib/invest_orchestrator_adapters.py
@@ -26,6 +26,7 @@ import yaml
 
 from scripts.lib import invest_coach as ic
 from scripts.lib import invest_ship_strategy as iss
+from scripts.lib import strategy_spec_integrity as ssi
 from scripts.lib import invest_thesis as it
 from scripts.lib import strategy_frontmatter as sf
 
@@ -388,6 +389,33 @@ def run_full_ship(
             }
         )
         staged = False
+
+        integrity = ssi.strategy_spec_integrity(strategy_path)
+        if not integrity.ok:
+            findings = tuple(integrity.findings)
+            events.append(
+                {
+                    "event": "strategy_spec_integrity_refused",
+                    "findings": [dict(finding) for finding in findings],
+                }
+            )
+            exc = OrchestratorGateError(
+                "strategy spec integrity refused: "
+                + "; ".join(finding["message"] for finding in findings)
+            )
+            exc.rollback_result = _rollback_ship_failure(
+                git_runner=git_runner,
+                repo_root=repo_root,
+                rel_path=rel_path,
+                strategy_path=strategy_path,
+                original=original,
+                original_sha=original_sha,
+                prior_exc=exc,
+                staged=staged,
+                events=events,
+            )
+            raise exc
+        events.append({"event": "strategy_spec_integrity_passed", "findings": []})
 
         plan_review = review_runner(
             ReviewRequest(

--- a/scripts/lib/strategy_spec_integrity.py
+++ b/scripts/lib/strategy_spec_integrity.py
@@ -1,0 +1,112 @@
+"""Deterministic strategy spec integrity preflight for ship adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from execution.strategies import loader
+from scripts.lib import strategy_frontmatter as sf
+
+
+@dataclass(frozen=True)
+class StrategySpecIntegrityResult:
+    """Stable result for deterministic strategy spec preflight checks."""
+
+    ok: bool
+    findings: tuple[dict[str, str], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable deterministic representation."""
+        return {
+            "ok": self.ok,
+            "findings": [dict(finding) for finding in self.findings],
+        }
+
+
+def strategy_spec_integrity(strategy_path: Path) -> StrategySpecIntegrityResult:
+    """Validate a strategy spec through deterministic K2Bi contracts.
+
+    The check is read-only. It refuses on parse, forward-guidance, loader,
+    or malformed present stop_loss errors. It never calls a model, reads a
+    clock, or mutates broker or engine state.
+    """
+
+    try:
+        return _strategy_spec_integrity(strategy_path)
+    except Exception as exc:
+        return _refusal(
+            "integrity_exception",
+            f"unexpected {type(exc).__name__} during integrity check",
+        )
+
+
+def _strategy_spec_integrity(strategy_path: Path) -> StrategySpecIntegrityResult:
+    """Run integrity checks; caller owns broad fail-closed exception guard."""
+
+    findings: list[dict[str, str]] = []
+    try:
+        content = strategy_path.read_bytes()
+    except OSError as exc:
+        return _refusal(
+            "read_error",
+            f"{strategy_path}: read failed: {exc}",
+        )
+
+    try:
+        frontmatter = sf.parse(content)
+    except ValueError as exc:
+        return _refusal("frontmatter_parse_error", str(exc))
+
+    try:
+        sf.validate_forward_guidance_check(
+            sf.extract_forward_guidance_check(frontmatter)
+        )
+    except ValueError as exc:
+        findings.append(_finding("forward_guidance_error", str(exc)))
+
+    stop_loss_error = _validate_present_stop_loss(frontmatter)
+    if stop_loss_error is not None:
+        findings.append(_finding("invalid_stop_loss", stop_loss_error))
+
+    try:
+        loader.load_document(strategy_path)
+    except loader.StrategyLoaderError as exc:
+        findings.append(_finding("loader_validation_error", str(exc)))
+
+    return StrategySpecIntegrityResult(ok=not findings, findings=tuple(findings))
+
+
+def _validate_present_stop_loss(frontmatter: dict[str, Any]) -> str | None:
+    order = frontmatter.get("order")
+    if not isinstance(order, dict) or "stop_loss" not in order:
+        return None
+    raw = order.get("stop_loss")
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return "order.stop_loss must be a valid number, got bool"
+    try:
+        value = Decimal(str(raw))
+    except (InvalidOperation, TypeError, ValueError):
+        return f"order.stop_loss must be a valid number, got {raw!r}"
+    if not value.is_finite():
+        return f"order.stop_loss must be finite, got {raw!r}"
+    return None
+
+
+def _finding(code: str, message: str) -> dict[str, str]:
+    return {
+        "code": code,
+        "severity": "refusal",
+        "message": message,
+    }
+
+
+def _refusal(code: str, message: str) -> StrategySpecIntegrityResult:
+    return StrategySpecIntegrityResult(
+        ok=False,
+        findings=(_finding(code, message),),
+    )

--- a/tests/fixtures/strategy_cdns.md
+++ b/tests/fixtures/strategy_cdns.md
@@ -1,0 +1,60 @@
+---
+tags:
+- strategy
+- cdns
+- k2bi
+date: '2026-06-07'
+type: strategy
+origin: k2bi-generate
+up: '[[index]]'
+name: cdns
+slug: cdns
+strategy_type: hand_crafted
+risk_envelope_pct: 0.0025
+regime_filter: []
+ticker: CDNS
+status: approved
+sigid: 2026-06-07-cdns-eda-compute-supply
+thesis_ref: '[[../tickers/CDNS]]'
+order:
+  ticker: CDNS
+  side: buy
+  qty: 1
+  order_type: LMT
+  limit_price: 330.0
+  stop_loss: 295.0
+  time_in_force: DAY
+forward_guidance_check:
+  completed_at: '2026-06-10T23:20:10.875865'
+  status: pass
+  override_reason: null
+  waive_reason: null
+  thresholded_metrics:
+  - metric: none
+    locked_threshold_text: No single thresholded guide metric
+    guide_source_text: 'operator-pasted: thesis is valuation/qualitative; no single
+      locked guide metric reconciles'
+    guide_range_text: no quantitative guide
+    sits_inside_guide: false
+approved_at: '2026-06-11T03:14:06.199024+00:00'
+approved_commit_sha: 0f7ff66
+---
+
+# Strategy: cdns
+
+## How This Works
+
+CDNS is a wide-moat EDA duopoly priced for perfection (~$376 = forward P/E ~47x, no margin of safety), so this is a patient, valuation-disciplined limit-entry plan that does nothing until price comes to it. It only engages on a de-rating toward the ~$330 fair-value floor, where the moat is no longer fully priced and risk/reward turns favorable. Buy only via a $330 limit order with the thesis conditions intact (firm backlog/RPO, normal China access, recurring mix holding >=80%), scale out into the $370/$410/$450 fair-value range, hard-stop at $295 below the floor, and kill on any thesis-invalidation signal. Direction is neutral at the current price; the plan stays dormant unless a de-rating entry triggers.
+
+## Entry Rules
+
+- Enter ONLY via a $330.00 limit order on a de-rating toward the fair-value floor; do not chase at the current ~$376 price.
+
+## Stop Rules
+
+- Initial hard stop at $295.00 (-11% from the $330 entry), below the fair-value floor, to cap risk on a de-rating overshoot or a China/operational shock.
+
+## Forward Guidance Reconciliation
+
+- Status: pass
+- none: No single thresholded guide metric; guide=no quantitative guide; inside=False

--- a/tests/test_invest_orchestrator_adapters.py
+++ b/tests/test_invest_orchestrator_adapters.py
@@ -1155,6 +1155,39 @@ class FullShipWrapperAdapterTests(unittest.TestCase):
         self.assertEqual(advisory[0]["verdict"], "NEEDS-ATTENTION")
         self.assertEqual(advisory[0]["log_path"], ".code-reviews/plan.log")
 
+    def test_strategy_spec_integrity_refuses_before_plan_review(self):
+        self.strategy_path = _write_strategy(
+            self.repo,
+            slug="spy",
+            missing_fields=["risk_envelope_pct"],
+        )
+
+        def review_runner(request: ioa.ReviewRequest) -> ioa.ReviewGateResult:
+            self.fail("plan review must not run before deterministic integrity")
+
+        with self.assertRaises(ioa.OrchestratorGateError) as cm:
+            ioa.run_full_ship(
+                self.strategy_path,
+                approval=self._approval(),
+                review_runner=review_runner,
+                approve_handler=self._approve_handler,
+                git_runner=lambda cmd, cwd: ioa.CommandResult(0, "", ""),
+            )
+
+        self.assertIn("strategy spec integrity", str(cm.exception).lower())
+        rollback = cm.exception.rollback_result
+        self.assertIsNotNone(rollback)
+        events = rollback.events
+        self.assertEqual(events[0]["event"], "ship_start")
+        refused = [
+            e for e in events
+            if e.get("event") == "strategy_spec_integrity_refused"
+        ]
+        self.assertEqual(len(refused), 1)
+        self.assertTrue(
+            any(f["code"] == "loader_validation_error" for f in refused[0]["findings"])
+        )
+
     def test_needs_attention_diff_review_is_advisory_and_commits(self):
         # ADVISORY (2026-06-10): a NEEDS-ATTENTION diff verdict no longer blocks the
         # strategy ship -- it is recorded as a diff_review_advisory event and the ship

--- a/tests/test_strategy_spec_integrity.py
+++ b/tests/test_strategy_spec_integrity.py
@@ -1,0 +1,102 @@
+"""Tests for deterministic strategy spec integrity preflight."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from execution.strategies import loader
+from scripts.lib import strategy_frontmatter as sf
+from scripts.lib.strategy_spec_integrity import strategy_spec_integrity
+from tests.test_invest_ship_strategy import _write_strategy
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _result_bytes(result) -> bytes:
+    return json.dumps(
+        result.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+class StrategySpecIntegrityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = Path(tempfile.mkdtemp(prefix="ssi_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.repo, ignore_errors=True)
+
+    def test_missing_required_loader_field_refuses_fail_closed(self):
+        path = _write_strategy(self.repo, missing_fields=["risk_envelope_pct"])
+
+        result = strategy_spec_integrity(path)
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(f["code"] == "loader_validation_error" for f in result.findings)
+        )
+        self.assertIn("risk_envelope_pct", json.dumps(result.to_dict()))
+
+    def test_present_non_numeric_stop_loss_refuses(self):
+        path = _write_strategy(self.repo, order={"stop_loss": "not-a-number"})
+
+        result = strategy_spec_integrity(path)
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(f["code"] == "invalid_stop_loss" for f in result.findings)
+        )
+
+    def test_real_cdns_fixture_passes_existing_contracts(self):
+        source = FIXTURES / "strategy_cdns.md"
+        target = self.repo / "wiki" / "strategies" / "strategy_cdns.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(source.read_bytes())
+        frontmatter = sf.parse(target.read_bytes())
+
+        self.assertIn("forward_guidance_check", frontmatter)
+        self.assertIn("stop_loss", frontmatter["order"])
+
+        result = strategy_spec_integrity(target)
+
+        self.assertTrue(result.ok, result.to_dict())
+        self.assertEqual(result.findings, ())
+
+    def test_unexpected_exception_returns_deterministic_refusal(self):
+        path = _write_strategy(self.repo)
+
+        with patch.object(loader, "load_document", side_effect=TypeError("unstable 0xabc")):
+            result = strategy_spec_integrity(path)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(len(result.findings), 1)
+        self.assertEqual(result.findings[0]["code"], "integrity_exception")
+        self.assertEqual(
+            result.findings[0]["message"],
+            "unexpected TypeError during integrity check",
+        )
+
+    def test_output_is_byte_identical_across_runs(self):
+        path = _write_strategy(self.repo)
+
+        outputs = [_result_bytes(strategy_spec_integrity(path)) for _ in range(5)]
+
+        self.assertEqual(outputs, [outputs[0]] * 5)
+
+    def test_exception_path_output_is_byte_identical_across_runs(self):
+        # The fail-closed guard must be deterministic on the EXCEPTION path too,
+        # not just the happy path: an unstable exception payload must never leak
+        # into the refusal, so the serialized result is byte-identical run to run.
+        path = _write_strategy(self.repo)
+
+        with patch.object(loader, "load_document", side_effect=TypeError("unstable 0xabc")):
+            outputs = [_result_bytes(strategy_spec_integrity(path)) for _ in range(5)]
+
+        self.assertEqual(outputs, [outputs[0]] * 5)


### PR DESCRIPTION
## What

Adds a deterministic `strategy_spec_integrity()` preflight inside `run_full_ship`, running **after the clean preflight and before the AI plan review**. It makes K2Bi's own objective contracts -- not the non-deterministic (now advisory) AI reviewer -- govern whether a strategy spec's frontmatter is structurally valid at the capital boundary.

## Why

The A3 ship review (Kimi via `minimax-review.sh`) is non-deterministic: the same CDNS spec returned different findings/verdict run to run, burning ship attempts. The reviews were already made advisory; this adds the missing deterministic backstop so a hand-edited or off-path spec can't reach the capital gate on the advisory AI alone. A read-only **Codex over-engineering pass** first caught that the original spec idea was based on two wrong premises and corrected the scope:

- **No `order_type: STP` rule.** The loader rejects `order_type: STP`; `LMT` + numeric `stop_loss` is the enforced bracket path (the `stop_loss` field creates the broker STP child). Requiring STP would break the loader.
- **No guidance-semantics flip.** K2Bi's contract is `status: pass` requires `sits_inside_guide: false`; the check **reuses** the existing `validate_forward_guidance_check()`.

## How

- New `scripts/lib/strategy_spec_integrity.py`: parses via existing `strategy_frontmatter.parse`, runs existing `validate_forward_guidance_check` + the loader order-shape validation, plus a `stop_loss`-is-numeric check. Pure / read-only / no model/clock/randomness -> byte-identical run to run. **Fail-closed:** any unexpected exception returns a deterministic `integrity_exception` refusal (type-name message only), never raises (interrupts still propagate -- `except Exception`, not `BaseException`).
- Wired into `run_full_ship`: refusals route through the **existing** rollback path with a `strategy_spec_integrity_refused` event; read-only on capital state (no broker/engine/.killed/commit-ownership change).

## Tests

New: determinism (happy + exception path, byte-identical x5), fail-closed on unexpected exception, malformed / non-numeric `stop_loss` refusal, CDNS fixture passes (with assertions it actually contains `stop_loss` + `forward_guidance_check`). **Full suite: 1844 passed, 1 skipped.**

## Provenance

Built by **Codex** in an isolated worktree; reviewed by **Kimi** over 3 rounds (cross-model, since Codex built it) -- 2 real fail-closed gaps fixed, the rest verified false-positive/out-of-scope. This is an **advisory PR from the K2B architect session** (K2B has architect-only rights on K2Bi). Spec + dispositions: `K2Bi-Vault/wiki/planning/feature_deterministic-ship-review-gate.md` (CORRECTED SCOPE section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)