### PR TITLE
fix(engine): self-renewing adopted-orphan-stop recognition + restart/liveness hardening

### DIFF
--- a/deploy/k2bi-engine-service-deploy.md
+++ b/deploy/k2bi-engine-service-deploy.md
@@ -1,0 +1,24 @@
+# k2bi-engine.service operator deploy note
+
+This repository template is the source artifact for the gated VPS unit update.
+It is not applied by this build.
+
+Operator deploy steps:
+
+1. Copy `deploy/k2bi-engine.service` to `/etc/systemd/system/k2bi-engine.service` on the VPS after review approval.
+2. Run `sudo systemctl daemon-reload`.
+3. Run `sudo systemctl restart k2bi-engine.service`.
+4. Verify with this copy-paste command:
+   `systemctl show k2bi-engine.service -p Restart -p StartLimitIntervalSec -p StartLimitBurst -p RestartSec`
+5. Verify the engine journals `engine_started` and reaches `active (running)`.
+
+Required policy values:
+
+- `Restart=always`
+- `RestartSec=30`
+- `StartLimitIntervalSec=10`
+- `StartLimitBurst=5`
+
+Rationale: clean closedown exits must restart, while a genuine sticky recovery
+mismatch should still trip systemd's start-limit burst and land in `failed`
+instead of looping indefinitely.

--- a/deploy/k2bi-engine.service
+++ b/deploy/k2bi-engine.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=K2Bi trading engine
+Requires=ib-gateway.service
+After=ib-gateway.service
+StartLimitIntervalSec=10
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=k2bi
+WorkingDirectory=/home/k2bi/Projects/K2Bi
+Environment=K2BI_VAULT_ROOT=/home/k2bi/Projects/K2Bi-Vault
+ExecStart=/home/k2bi/Projects/K2Bi/.venv/bin/python -m execution.engine.main --account-id DUQ220152
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/execution/engine/main.py
+++ b/execution/engine/main.py
@@ -1109,7 +1109,15 @@ class Engine:
             ext_since=ext_lookback_start,
             narrow_since=narrow_lookback_start,
         )
-        journal_tail = extended_checkpoints + narrow_journal_tail
+        orphan_adoption_history = _read_orphan_stop_adoption_history(
+            self.journal,
+            exclude_since=ext_lookback_start,
+        )
+        journal_tail = (
+            orphan_adoption_history
+            + extended_checkpoints
+            + narrow_journal_tail
+        )
         self._refresh_pending_orders_from_journal(now=startup_now)
         self._refresh_rapid_fire_state_from_journal(now=startup_now)
 
@@ -4565,6 +4573,55 @@ def _read_extended_checkpoints(
                 continue
             if ts >= narrow_since.isoformat():
                 continue  # already covered by narrow tail
+            out.append(rec)
+    out.sort(key=lambda r: str(r.get("ts", "")))
+    return out
+
+
+def _read_orphan_stop_adoption_history(
+    journal: JournalWriter,
+    *,
+    exclude_since: datetime,
+) -> list[dict[str, Any]]:
+    """Read older orphan_stop_adopted records without extending all checkpoints.
+
+    A-i renewal needs durable proof that a human adopted the orphan
+    STOP at least once. Only that event type is scanned outside the
+    30-day checkpoint window; engine_recovered and other checkpoint
+    semantics stay bounded by the existing recovery contract.
+    """
+    out: list[dict[str, Any]] = []
+    base_dir = getattr(journal, "base_dir", None)
+    if base_dir is None:
+        return out
+    try:
+        paths = sorted(Path(base_dir).glob("*.jsonl"))
+    except OSError as exc:  # pragma: no cover - defensive FS guard
+        LOG.warning("orphan-adoption history scan failed: %s", exc)
+        return out
+    exclude_iso = exclude_since.isoformat()
+    for path in paths:
+        try:
+            when = datetime.fromisoformat(path.stem).replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            continue
+        try:
+            day_records = journal.read_all(when)
+        except Exception as exc:  # pragma: no cover - shouldn't raise
+            LOG.warning(
+                "orphan-adoption history read_all(%s) raised: %s",
+                when,
+                exc,
+            )
+            continue
+        for rec in day_records:
+            if rec.get("event_type") != "orphan_stop_adopted":
+                continue
+            ts = str(rec.get("ts", ""))
+            if not ts or ts >= exclude_iso:
+                continue
             out.append(rec)
     out.sort(key=lambda r: str(r.get("ts", "")))
     return out

--- a/execution/engine/recovery.py
+++ b/execution/engine/recovery.py
@@ -114,6 +114,7 @@ EXTENDED_CHECKPOINT_LOOKBACK = timedelta(days=30)
 EXTENDED_CHECKPOINT_EVENT_TYPES: frozenset[str] = frozenset(
     {"engine_recovered", "orphan_stop_adopted"}
 )
+ADOPTED_ORPHAN_AVG_PRICE_EPSILON = Decimal("0.01")
 
 
 @dataclass(frozen=True)
@@ -125,6 +126,20 @@ class OrphanStopAdoptionRequest:
 
     perm_id: int
     justification: str
+
+
+@dataclass(frozen=True)
+class AdoptedOrphanStop:
+    """Latest journaled human adoption state for one orphan STOP permId."""
+
+    perm_id: int
+    ticker: str
+    qty: int
+    stop_price: Decimal
+    source: str
+    adopted_at: str
+    justification: str
+    journal_entry_id: str | None = None
 
 
 def _parse_adopt_orphan_stop(raw: str | None) -> OrphanStopAdoptionRequest | None:
@@ -165,6 +180,69 @@ def _parse_adopt_orphan_stop(raw: str | None) -> OrphanStopAdoptionRequest | Non
             f"{ADOPT_ORPHAN_STOP_ENV} justification must be non-empty"
         )
     return OrphanStopAdoptionRequest(perm_id=perm_id, justification=just)
+
+
+def _adopted_orphan_stops_by_perm_id(
+    records: Iterable[dict[str, Any]],
+) -> dict[str, AdoptedOrphanStop]:
+    """Latest valid orphan STOP adoption payload per permId.
+
+    This is the capital-path version of the older permId-only helper:
+    recognition requires the broker order and held position to still
+    match the human-adopted permId, ticker, quantity, and trigger.
+    """
+    out: dict[str, AdoptedOrphanStop] = {}
+    for rec in records:
+        if rec.get("event_type") != "orphan_stop_adopted":
+            continue
+        payload = rec.get("payload") or {}
+        perm = payload.get("permId")
+        ticker = payload.get("ticker")
+        qty = payload.get("qty")
+        source = payload.get("source")
+        adopted_at = payload.get("adopted_at")
+        justification = payload.get("justification")
+        try:
+            if isinstance(perm, bool) or int(perm) <= 0:
+                continue
+            if not isinstance(ticker, str) or not ticker.strip():
+                continue
+            if isinstance(qty, bool) or int(qty) == 0:
+                continue
+            stop_price = Decimal(str(payload.get("stop_price")))
+        except (InvalidOperation, TypeError, ValueError):
+            continue
+        if not stop_price.is_finite() or stop_price <= 0:
+            continue
+        if not isinstance(source, str) or not source:
+            continue
+        if not isinstance(adopted_at, str) or not adopted_at:
+            continue
+        if not isinstance(justification, str) or not justification.strip():
+            continue
+        out[str(int(perm))] = AdoptedOrphanStop(
+            perm_id=int(perm),
+            ticker=ticker,
+            qty=int(qty),
+            stop_price=stop_price,
+            source=source,
+            adopted_at=adopted_at,
+            justification=justification,
+            journal_entry_id=(
+                str(rec.get("journal_entry_id"))
+                if rec.get("journal_entry_id") is not None
+                else None
+            ),
+        )
+    return out
+
+
+def _avg_prices_equivalent_for_adopted_stop(
+    left: Decimal,
+    right: Decimal,
+) -> bool:
+    """Return True when avg_price drift is cent-level rounding noise."""
+    return abs(left - right) <= ADOPTED_ORPHAN_AVG_PRICE_EPSILON
 
 
 def _adopted_orphan_perm_ids(records: Iterable[dict[str, Any]]) -> set[str]:
@@ -364,29 +442,11 @@ def reconcile(
     status_index = _index_status_events(broker_order_status)
     open_index = _index_open_orders(broker_open_orders)
     seen_broker_ids: set[str] = set()
-    # Q42: orphan_stop_adopted events from prior recovery passes pre-mark
-    # their permIds as known so the Phase B.1 orphan loop skips them.
-    # Same recognition mechanism Phase A's perm/oid matching uses.
-    # Q42 +1 week carry-forward (2026-05-03) extends the lookup window
-    # via `_read_extended_checkpoints` so multi-day engine-off gaps
-    # don't re-flag adopted orphans as phantoms. Capital-path safety
-    # gate per cross-mode adversarial review (Kimi + Codex 2026-05-03):
-    # an adopted permId only suppresses phantom_open_order when the
-    # broker STILL HOLDS a position in the order's ticker. A stale
-    # adoption whose underlying position has been closed must fall
-    # through to phantom detection -- the orphan STOP would otherwise
-    # be live at the broker without an associated long position to
-    # protect, and engine state cannot reason about it safely.
-    adopted_perm_to_ticker = _adopted_orphan_perm_id_to_ticker(journal_tail)
-    broker_position_tickers = {p.ticker for p in broker_positions}
-    for adopted_perm in _adopted_orphan_perm_ids(journal_tail):
-        ticker = adopted_perm_to_ticker.get(str(adopted_perm))
-        if ticker is not None and ticker not in broker_position_tickers:
-            # Stale orphan adoption: ticker no longer at broker.
-            # Skip the carry-forward; phantom_open_order will fire
-            # for the live STOP order and surface the divergence.
-            continue
-        seen_broker_ids.add(f"perm:{adopted_perm}")
+    # Q42/A-i: prior human adoptions are considered later, after
+    # projected positions are known. Recognition is exact-state based,
+    # not permId-only: the same stop must still protect the same held
+    # position or recovery re-refuses.
+    adopted_orphan_stops = _adopted_orphan_stops_by_perm_id(journal_tail)
     # Per-ticker (signed_qty_delta, last_broker_avg_fill_price).
     # Positive qty means the pending was a buy that filled, growing
     # inventory; negative means a sell that filled, reducing it.
@@ -610,6 +670,113 @@ def reconcile(
             else:
                 new_avg = old_avg
             projected_by_ticker[ticker] = (new_qty, new_avg)
+
+    broker_by_ticker = {p.ticker: p for p in broker_positions}
+
+    # ---- Q42/A-i: exact-state renewal for human-adopted orphan STOPs ----
+    #
+    # This preserves the human-first adoption gate: a broker orphan is
+    # recognized only if an earlier orphan_stop_adopted record exists.
+    # The renewal is automatic only while the broker still holds the
+    # same position and the same STOP identity (permId/qty/trigger).
+    # Any drift falls through to phantom detection and also emits a
+    # specific drift mismatch for operator review.
+    open_by_perm = {
+        str(o.broker_perm_id): o
+        for o in broker_open_orders
+        if o.broker_perm_id is not None
+    }
+    renewal_events: list[ReconciliationEvent] = []
+    for perm, adoption in adopted_orphan_stops.items():
+        open_order = open_by_perm.get(perm)
+        if open_order is None:
+            continue
+        broker_pos = broker_by_ticker.get(adoption.ticker)
+        projected = projected_by_ticker.get(adoption.ticker)
+        if broker_pos is None or projected is None:
+            # Do not pre-mark this permId as seen. A live adopted STOP
+            # without a matching held position is a naked stop and must
+            # fall through Phase B.1 as phantom_open_order.
+            continue
+        projected_qty, projected_avg = projected
+        order_type_norm = (open_order.order_type or "").upper().strip()
+        drift_reasons: list[str] = []
+        if open_order.ticker != adoption.ticker:
+            drift_reasons.append("ticker")
+        if open_order.qty != adoption.qty:
+            drift_reasons.append("qty")
+        if open_order.aux_price != adoption.stop_price:
+            drift_reasons.append("stop_price")
+        if open_order.side.lower() != "sell":
+            drift_reasons.append("side")
+        if order_type_norm not in ("STP", "STP LMT"):
+            drift_reasons.append("order_type")
+        if broker_pos.qty != adoption.qty or projected_qty != adoption.qty:
+            drift_reasons.append("position_qty")
+        if not _avg_prices_equivalent_for_adopted_stop(
+            broker_pos.avg_price,
+            projected_avg,
+        ):
+            drift_reasons.append("position_avg_price")
+        if drift_reasons:
+            mismatches.append(
+                {
+                    "case": "adopted_orphan_stop_drift",
+                    "broker_perm_id": open_order.broker_perm_id,
+                    "ticker": adoption.ticker,
+                    "drift_fields": drift_reasons,
+                    "adopted": {
+                        "permId": adoption.perm_id,
+                        "ticker": adoption.ticker,
+                        "qty": adoption.qty,
+                        "stop_price": str(adoption.stop_price),
+                        "adopted_at": adoption.adopted_at,
+                        "journal_entry_id": adoption.journal_entry_id,
+                    },
+                    "broker": {
+                        "ticker": open_order.ticker,
+                        "qty": open_order.qty,
+                        "stop_price": str(open_order.aux_price),
+                        "side": open_order.side,
+                        "order_type": open_order.order_type,
+                        "position_qty": broker_pos.qty,
+                        "position_avg_price": str(broker_pos.avg_price),
+                    },
+                    "reason": (
+                        "previous human adoption exists, but the broker "
+                        "stop or held position no longer matches it; "
+                        "operator must re-review before relaunching"
+                    ),
+                }
+            )
+            continue
+        seen_broker_ids.add(f"perm:{perm}")
+        if open_order.broker_order_id:
+            seen_broker_ids.add(f"oid:{open_order.broker_order_id}")
+        from ..journal.schema import validate_orphan_stop_adopted_payload
+
+        renewal_payload = {
+            "permId": adoption.perm_id,
+            "ticker": adoption.ticker,
+            "qty": adoption.qty,
+            "stop_price": str(adoption.stop_price),
+            "source": adoption.source,
+            "adopted_at": now.isoformat(),
+            "justification": (
+                "renewed unchanged human adoption"
+                f" from {adoption.journal_entry_id or adoption.adopted_at}"
+            ),
+        }
+        validate_orphan_stop_adopted_payload(renewal_payload)
+        renewal_events.append(
+            ReconciliationEvent(
+                event_type="orphan_stop_adopted",
+                payload=renewal_payload,
+                ticker=adoption.ticker,
+                broker_order_id=open_order.broker_order_id,
+                broker_perm_id=perm,
+            )
+        )
 
     # ---- Phase B.1: phantom open orders ----
 
@@ -869,8 +1036,6 @@ def reconcile(
         )
 
     # ---- Phase B.2: position diff against projected state ----
-
-    broker_by_ticker = {p.ticker: p for p in broker_positions}
 
     for ticker, broker_pos in broker_by_ticker.items():
         projected = projected_by_ticker.get(ticker)
@@ -1342,6 +1507,9 @@ def reconcile(
                 )
 
     # ---- 4. status assembly ----
+
+    if not mismatches and renewal_events:
+        events.extend(renewal_events)
 
     if not mismatches and not events and not broker_positions and not broker_open_orders:
         status = RecoveryStatus.CLEAN

--- a/scripts/deploy-config.yml
+++ b/scripts/deploy-config.yml
@@ -89,6 +89,9 @@ excludes:
   - wiki
   # Design docs + research workspace (MacBook dev tier only)
   - proposals
+  # Repo-tracked operator templates and deploy notes. These are copied
+  # manually during gated operator deploys, not rsync-managed payloads.
+  - deploy
   - plans
   - .claude/plans                # duplicate of above for belt-and-braces parsing
   # Agent-facing docs (operator/developer context — content references MacBook paths,

--- a/scripts/invest_alert_lib.py
+++ b/scripts/invest_alert_lib.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 # Allow importing execution.* when this file is run directly (cron path)
 if __name__ == "__main__" and __package__ is None:
@@ -31,8 +32,10 @@ if __name__ == "__main__" and __package__ is None:
 from execution.risk.kill_switch import _scan_kill_paths, is_killed
 
 DEFAULT_OUTAGE_THRESHOLD_S = 300
+DEFAULT_LIVENESS_STALE_AFTER_S = 300
 DEFAULT_VAULT_ROOT = Path.home() / "Projects" / "K2Bi-Vault"
 DEFAULT_STATE_DIR = Path.home() / ".k2bi"
+ENGINE_SERVICE = "k2bi-engine.service"
 
 # Journal files are named YYYY-MM-DD.jsonl in raw/journal/
 JOURNAL_DIR = "raw/journal"
@@ -81,6 +84,7 @@ class ClassifierState:
     last_processed_ts: str | None = None
     alerted_outage_start_ts: str | None = None  # first disconnect_status ts of current alerted outage
     kill_switch_state: str = "unknown"  # "unknown" | "clear" | "active"
+    alerted_liveness_key: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -88,6 +92,7 @@ class ClassifierState:
             "last_processed_ts": self.last_processed_ts,
             "alerted_outage_start_ts": self.alerted_outage_start_ts,
             "kill_switch_state": self.kill_switch_state,
+            "alerted_liveness_key": self.alerted_liveness_key,
         }
 
     @classmethod
@@ -97,6 +102,7 @@ class ClassifierState:
             last_processed_ts=d.get("last_processed_ts"),
             alerted_outage_start_ts=d.get("alerted_outage_start_ts"),
             kill_switch_state=d.get("kill_switch_state", "unknown"),
+            alerted_liveness_key=d.get("alerted_liveness_key"),
         )
 
 
@@ -437,6 +443,149 @@ def _build_kill_switch_clear_alert() -> Alert:
     )
 
 
+def _read_engine_systemd_state() -> str:
+    """Return systemd is-active state for the engine service."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", ENGINE_SERVICE],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _is_market_hours_utc(now: datetime) -> bool:
+    """Approximate US regular session for liveness journal-staleness checks."""
+    utc_now = now.astimezone(timezone.utc)
+    if utc_now.weekday() >= 5:
+        return False
+    minutes = utc_now.hour * 60 + utc_now.minute
+    return (13 * 60 + 30) <= minutes <= (20 * 60)
+
+
+def _build_engine_liveness_alert(
+    *,
+    now: datetime,
+    reason: str,
+    engine_state: str,
+    latest_event: dict[str, Any] | None,
+    stale_seconds: float | None = None,
+) -> Alert:
+    latest_ts = latest_event.get("ts") if latest_event else "none"
+    latest_id = latest_event.get("journal_entry_id") if latest_event else "none"
+    lines = [
+        "🔴 T1: engine_liveness",
+        f"Reason: {reason}",
+        f"systemd: {engine_state}",
+        f"Latest journal: {latest_ts}",
+    ]
+    if stale_seconds is not None:
+        lines.append(f"Stale for: {_fmt_outage(stale_seconds)}")
+    return Alert(
+        tier=1,
+        event_type="engine_liveness",
+        journal_entry_id=str(latest_id or ""),
+        ts=now.isoformat(),
+        message="\n".join(lines),
+        context={
+            "reason": reason,
+            "engine_state": engine_state,
+            "latest_journal_ts": latest_ts,
+            "stale_seconds": stale_seconds,
+        },
+    )
+
+
+def _liveness_alerts(
+    *,
+    state: ClassifierState,
+    vault_root: Path,
+    today: datetime.date | None,
+    now: datetime,
+    engine_state_reader: Callable[[], str],
+    market_hours_reader: Callable[[datetime], bool],
+    stale_after_seconds: int,
+) -> tuple[list[Alert], bool]:
+    engine_state = engine_state_reader()
+    latest_event = _find_latest_journal_event(vault_root, today)
+    alerts: list[Alert] = []
+    changed = False
+
+    if engine_state == "unknown":
+        return alerts, changed
+
+    if engine_state != "active":
+        key = f"inactive:{engine_state}"
+        if state.alerted_liveness_key != key:
+            state.alerted_liveness_key = key
+            changed = True
+            alerts.append(
+                _build_engine_liveness_alert(
+                    now=now,
+                    reason=f"engine inactive ({engine_state})",
+                    engine_state=engine_state,
+                    latest_event=latest_event,
+                )
+            )
+        return alerts, changed
+
+    if latest_event is None:
+        if not market_hours_reader(now):
+            state.alerted_liveness_key = None
+            return alerts, changed
+        key = "stale:no-journal"
+        if state.alerted_liveness_key != key:
+            state.alerted_liveness_key = key
+            changed = True
+            alerts.append(
+                _build_engine_liveness_alert(
+                    now=now,
+                    reason="journal stale: no journal event found",
+                    engine_state=engine_state,
+                    latest_event=None,
+                    stale_seconds=None,
+                )
+            )
+        return alerts, changed
+
+    latest_ts_raw = latest_event.get("ts")
+    try:
+        latest_ts = datetime.fromisoformat(
+            str(latest_ts_raw).replace("Z", "+00:00")
+        )
+    except (TypeError, ValueError):
+        latest_ts = None
+    if latest_ts is None:
+        return alerts, changed
+    if latest_ts.tzinfo is None:
+        latest_ts = latest_ts.replace(tzinfo=timezone.utc)
+    stale_seconds = (
+        now.astimezone(timezone.utc) - latest_ts.astimezone(timezone.utc)
+    ).total_seconds()
+    if stale_seconds >= stale_after_seconds and market_hours_reader(now):
+        key = f"stale:{latest_event.get('journal_entry_id')}"
+        if state.alerted_liveness_key != key:
+            state.alerted_liveness_key = key
+            changed = True
+            alerts.append(
+                _build_engine_liveness_alert(
+                    now=now,
+                    reason="journal stale",
+                    engine_state=engine_state,
+                    latest_event=latest_event,
+                    stale_seconds=stale_seconds,
+                )
+            )
+    elif state.alerted_liveness_key is not None:
+        state.alerted_liveness_key = None
+        changed = True
+    return alerts, changed
+
+
 def classify_events(
     events: list[dict[str, Any]],
     state: ClassifierState,
@@ -448,6 +597,8 @@ def classify_events(
         last_processed_entry_id=state.last_processed_entry_id,
         last_processed_ts=state.last_processed_ts,
         alerted_outage_start_ts=state.alerted_outage_start_ts,
+        kill_switch_state=state.kill_switch_state,
+        alerted_liveness_key=state.alerted_liveness_key,
     )
 
     # Track the current contiguous disconnect sequence.
@@ -525,6 +676,10 @@ def run_classification(
     threshold: int | None = None,
     today: datetime.date | None = None,
     commit_state: bool = True,
+    now: datetime | None = None,
+    engine_state_reader: Callable[[], str] | None = None,
+    market_hours_reader: Callable[[datetime], bool] | None = None,
+    liveness_stale_after_seconds: int | None = None,
 ) -> tuple[list[Alert], ClassifierState, bool]:
     """Main entry point: load state, read journal, classify, optionally save state.
 
@@ -536,6 +691,19 @@ def run_classification(
         state_dir = Path(os.environ.get("K2BI_ALERT_STATE_DIR", DEFAULT_STATE_DIR)).expanduser()
     if threshold is None:
         threshold = int(os.environ.get("K2BI_ALERT_OUTAGE_THRESHOLD_S", DEFAULT_OUTAGE_THRESHOLD_S))
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if engine_state_reader is None:
+        engine_state_reader = _read_engine_systemd_state
+    if market_hours_reader is None:
+        market_hours_reader = _is_market_hours_utc
+    if liveness_stale_after_seconds is None:
+        liveness_stale_after_seconds = int(
+            os.environ.get(
+                "K2BI_ENGINE_LIVENESS_STALE_THRESHOLD_S",
+                DEFAULT_LIVENESS_STALE_AFTER_S,
+            )
+        )
 
     state, state_file_existed = load_state(state_dir)
 
@@ -579,12 +747,26 @@ def run_classification(
 
     events = _iter_new_events(vault_root, state, today)
     alerts, new_state = classify_events(events, state, threshold)
+    liveness_alerts, liveness_changed = _liveness_alerts(
+        state=new_state,
+        vault_root=vault_root,
+        today=today,
+        now=now,
+        engine_state_reader=engine_state_reader,
+        market_hours_reader=market_hours_reader,
+        stale_after_seconds=liveness_stale_after_seconds,
+    )
 
-    # Merge kill-switch alerts at the front
-    alerts = kill_switch_alerts + alerts
+    # Merge state-derived alerts at the front
+    alerts = kill_switch_alerts + liveness_alerts + alerts
     new_state.kill_switch_state = current_kill_state
 
-    state_changed = bool(events) or bool(kill_switch_alerts) or kill_switch_state_changed
+    state_changed = (
+        bool(events)
+        or bool(kill_switch_alerts)
+        or kill_switch_state_changed
+        or liveness_changed
+    )
     if state_changed and commit_state:
         save_state(new_state, state_dir)
     return alerts, new_state, state_changed

--- a/tests/test_engine_recovery.py
+++ b/tests/test_engine_recovery.py
@@ -3246,12 +3246,444 @@ class Q42OrphanStopAdoptionTests(unittest.TestCase):
             f"pass 2 should be CATCH_UP (perm in journal), got "
             f"{pass2.status} mismatches={pass2.mismatch_reasons}",
         )
-        # Pass 2 must NOT write another adoption event -- it's already
-        # in the journal.
+        # A-i self-renews the human adoption while the stop and
+        # position remain unchanged, so the next restart has a fresh
+        # orphan_stop_adopted checkpoint instead of a fixed 30-day
+        # expiry.
         new_adoptions = [
             e for e in pass2.events if e.event_type == "orphan_stop_adopted"
         ]
-        self.assertEqual(new_adoptions, [])
+        self.assertEqual(len(new_adoptions), 1)
+        self.assertEqual(new_adoptions[0].payload["permId"], 1888063981)
+        self.assertIn(
+            "renew", new_adoptions[0].payload["justification"].lower()
+        )
+
+    def test_q42_self_renews_prior_human_adoption_when_stop_and_position_unchanged(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[self._engine_recovered_journal(), old_adoption],
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.22")
+                )
+            ],
+            broker_open_orders=[self._orphan_stop(perm_id="1888063981")],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.CATCH_UP,
+            f"unchanged adopted orphan should recover; got "
+            f"{result.status} mismatches={result.mismatch_reasons}",
+        )
+        renewals = [
+            e for e in result.events if e.event_type == "orphan_stop_adopted"
+        ]
+        self.assertEqual(len(renewals), 1)
+        self.assertEqual(renewals[0].payload["permId"], 1888063981)
+        self.assertEqual(renewals[0].payload["ticker"], "SPY")
+        self.assertEqual(renewals[0].payload["qty"], 2)
+        self.assertEqual(renewals[0].payload["stop_price"], "697.13")
+        self.assertEqual(renewals[0].payload["adopted_at"], NOW.isoformat())
+        self.assertIn("renew", renewals[0].payload["justification"].lower())
+
+    def test_q42_old_expired_adoption_recovers_only_when_history_is_present(self):
+        old_adoption = {
+            "ts": "2026-04-01T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-expired-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-04-01T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        position_seed = self._engine_recovered_journal()
+        positions = [
+            BrokerPosition(
+                ticker="SPY", qty=2, avg_price=Decimal("707.22")
+            )
+        ]
+        orphan = self._orphan_stop(perm_id="1888063981")
+
+        old_window = recovery.reconcile(
+            journal_tail=[position_seed],
+            broker_positions=positions,
+            broker_open_orders=[orphan],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            old_window.status, recovery.RecoveryStatus.MISMATCH_REFUSED
+        )
+        self.assertIn(
+            "phantom_open_order",
+            [m["case"] for m in old_window.mismatch_reasons],
+        )
+
+        new_history = recovery.reconcile(
+            journal_tail=[old_adoption, position_seed],
+            broker_positions=positions,
+            broker_open_orders=[orphan],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            new_history.status,
+            recovery.RecoveryStatus.CATCH_UP,
+            f"expired but unchanged adoption should self-renew; "
+            f"mismatches={new_history.mismatch_reasons}",
+        )
+        renewals = [
+            e
+            for e in new_history.events
+            if e.event_type == "orphan_stop_adopted"
+        ]
+        self.assertEqual(len(renewals), 1)
+
+    def test_q42_self_renewal_allows_avg_price_rounding_noise(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[
+                self._engine_recovered_journal(avg_price="707.224"),
+                old_adoption,
+            ],
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.22")
+                )
+            ],
+            broker_open_orders=[self._orphan_stop(perm_id="1888063981")],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status,
+            recovery.RecoveryStatus.CATCH_UP,
+            f"cent-level avg_price rounding noise must not refuse; "
+            f"mismatches={result.mismatch_reasons}",
+        )
+
+    def test_q42_self_renewal_refuses_real_avg_price_drift(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[
+                self._engine_recovered_journal(avg_price="707.22"),
+                old_adoption,
+            ],
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.25")
+                )
+            ],
+            broker_open_orders=[self._orphan_stop(perm_id="1888063981")],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status, recovery.RecoveryStatus.MISMATCH_REFUSED
+        )
+        drift = [
+            m
+            for m in result.mismatch_reasons
+            if m["case"] == "adopted_orphan_stop_drift"
+        ]
+        self.assertEqual(len(drift), 1)
+        self.assertIn("position_avg_price", drift[0]["drift_fields"])
+
+    def test_q42_self_renewal_refuses_when_adopted_stop_qty_drifted(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[self._engine_recovered_journal(), old_adoption],
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.22")
+                )
+            ],
+            broker_open_orders=[
+                self._orphan_stop(perm_id="1888063981", qty=1)
+            ],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status, recovery.RecoveryStatus.MISMATCH_REFUSED
+        )
+        cases = [m["case"] for m in result.mismatch_reasons]
+        self.assertIn("adopted_orphan_stop_drift", cases)
+        self.assertIn("phantom_open_order", cases)
+        self.assertEqual(
+            [
+                e
+                for e in result.events
+                if e.event_type == "orphan_stop_adopted"
+            ],
+            [],
+        )
+
+    def test_q42_self_renewal_refuses_when_adopted_stop_price_drifted(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[self._engine_recovered_journal(), old_adoption],
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.22")
+                )
+            ],
+            broker_open_orders=[
+                self._orphan_stop(
+                    perm_id="1888063981", aux_price="650.00"
+                )
+            ],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status, recovery.RecoveryStatus.MISMATCH_REFUSED
+        )
+        drift = [
+            m
+            for m in result.mismatch_reasons
+            if m["case"] == "adopted_orphan_stop_drift"
+        ]
+        self.assertEqual(len(drift), 1)
+        self.assertIn("stop_price", drift[0]["drift_fields"])
+        self.assertEqual(
+            [
+                e
+                for e in result.events
+                if e.event_type == "orphan_stop_adopted"
+            ],
+            [],
+        )
+
+    def test_q42_self_renewal_refuses_when_adopted_stop_perm_id_changed(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[self._engine_recovered_journal(), old_adoption],
+            broker_positions=[
+                BrokerPosition(
+                    ticker="SPY", qty=2, avg_price=Decimal("707.22")
+                )
+            ],
+            broker_open_orders=[
+                self._orphan_stop(
+                    perm_id="999999", order_id="10099"
+                )
+            ],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status, recovery.RecoveryStatus.MISMATCH_REFUSED
+        )
+        cases = [m["case"] for m in result.mismatch_reasons]
+        self.assertIn("phantom_open_order", cases)
+        self.assertEqual(
+            [
+                e
+                for e in result.events
+                if e.event_type == "orphan_stop_adopted"
+            ],
+            [],
+        )
+
+    def test_q42_self_renewal_refuses_when_position_is_gone(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[self._engine_recovered_journal(), old_adoption],
+            broker_positions=[],
+            broker_open_orders=[self._orphan_stop(perm_id="1888063981")],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status, recovery.RecoveryStatus.MISMATCH_REFUSED
+        )
+        cases = [m["case"] for m in result.mismatch_reasons]
+        self.assertIn("phantom_open_order", cases)
+        self.assertIn("journal_position_missing_at_broker", cases)
+        self.assertEqual(
+            [
+                e
+                for e in result.events
+                if e.event_type == "orphan_stop_adopted"
+            ],
+            [],
+        )
+
+    def test_q42_naked_adopted_stop_without_any_position_refuses(self):
+        old_adoption = {
+            "ts": "2026-05-03T14:30:00+00:00",
+            "event_type": "orphan_stop_adopted",
+            "trade_id": "",
+            "journal_entry_id": "J-old-adoption",
+            "strategy": "",
+            "git_sha": "abc",
+            "broker_perm_id": "1888063981",
+            "payload": {
+                "permId": 1888063981,
+                "ticker": "SPY",
+                "qty": 2,
+                "stop_price": "697.13",
+                "source": "operator-portal",
+                "adopted_at": "2026-05-03T14:30:00+00:00",
+                "justification": "original human adoption",
+            },
+        }
+        result = recovery.reconcile(
+            journal_tail=[old_adoption],
+            broker_positions=[],
+            broker_open_orders=[self._orphan_stop(perm_id="1888063981")],
+            broker_order_status=[],
+            now=NOW,
+            override_env="",
+        )
+        self.assertEqual(
+            result.status, recovery.RecoveryStatus.MISMATCH_REFUSED
+        )
+        self.assertIn(
+            "phantom_open_order",
+            [m["case"] for m in result.mismatch_reasons],
+        )
 
     def test_q42_multiple_orphans_only_one_adopted_still_refuses(self):
         # Two unknown STOPs at broker; architect adopts only permId=42.

--- a/tests/test_engine_systemd_service_template.py
+++ b/tests/test_engine_systemd_service_template.py
@@ -1,0 +1,61 @@
+"""Tests for the repo-tracked k2bi-engine systemd unit template.
+
+The live VPS unit is operator-owned. These tests only validate the
+repository template that the PR will hand to the operator for gated
+deployment.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_TEMPLATE = ROOT / "deploy" / "k2bi-engine.service"
+DEPLOY_NOTE = ROOT / "deploy" / "k2bi-engine-service-deploy.md"
+
+
+def _service_assignments() -> dict[str, str]:
+    assignments: dict[str, str] = {}
+    for raw in SERVICE_TEMPLATE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        assignments[key.strip()] = value.strip()
+    return assignments
+
+
+class EngineSystemdServiceTemplateTests(unittest.TestCase):
+    def test_template_restarts_after_clean_exit_but_keeps_burst_limit(self):
+        self.assertTrue(
+            SERVICE_TEMPLATE.exists(),
+            f"missing repo-tracked service template: {SERVICE_TEMPLATE}",
+        )
+        assignments = _service_assignments()
+        self.assertEqual(assignments.get("Restart"), "always")
+        self.assertNotEqual(assignments.get("Restart"), "on-failure")
+        self.assertEqual(assignments.get("RestartSec"), "30")
+        self.assertEqual(assignments.get("StartLimitIntervalSec"), "10")
+        self.assertEqual(assignments.get("StartLimitBurst"), "5")
+
+    def test_operator_deploy_note_documents_gated_vps_install(self):
+        self.assertTrue(
+            DEPLOY_NOTE.exists(),
+            f"missing operator deploy note: {DEPLOY_NOTE}",
+        )
+        text = DEPLOY_NOTE.read_text(encoding="utf-8")
+        self.assertIn("/etc/systemd/system/k2bi-engine.service", text)
+        self.assertIn("systemctl daemon-reload", text)
+        self.assertIn("operator", text.lower())
+        self.assertIn("Restart=always", text)
+        self.assertIn(
+            "systemctl show k2bi-engine.service -p Restart "
+            "-p StartLimitIntervalSec -p StartLimitBurst -p RestartSec",
+            text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_invest_alert_lib.py
+++ b/tests/test_invest_alert_lib.py
@@ -11,6 +11,7 @@ import json
 import os
 import tempfile
 import unittest
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -177,6 +178,169 @@ class Tier1OtherTests(unittest.TestCase):
             "circuit_breaker_cleared_stale_sentinel_rejected",
         )
         self.assertIn("Operator review required", alerts[0].message)
+
+
+class EngineLivenessTests(unittest.TestCase):
+    def test_inactive_engine_fires_tier1_liveness_alert_with_injected_state(self):
+        now = datetime(2026, 6, 15, 14, 40, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as td:
+            vault_root = Path(td) / "vault"
+            state_dir = Path(td) / "state"
+            state_dir.mkdir()
+            (state_dir / "alert-state.json").write_text(
+                json.dumps({"kill_switch_state": "clear"}),
+                encoding="utf-8",
+            )
+            alerts, state, changed = ial.run_classification(
+                vault_root=vault_root,
+                state_dir=state_dir,
+                today=date(2026, 6, 15),
+                commit_state=False,
+                now=now,
+                engine_state_reader=lambda: "inactive",
+                market_hours_reader=lambda when: True,
+            )
+        self.assertTrue(changed)
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(alerts[0].tier, 1)
+        self.assertEqual(alerts[0].event_type, "engine_liveness")
+        self.assertIn("inactive", alerts[0].message)
+
+    def test_active_engine_with_stale_journal_fires_liveness_alert(self):
+        now = datetime(2026, 6, 15, 14, 40, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as td:
+            vault_root = Path(td) / "vault"
+            state_dir = Path(td) / "state"
+            state_dir.mkdir()
+            (state_dir / "alert-state.json").write_text(
+                json.dumps(
+                    {
+                        "last_processed_entry_id": "id01",
+                        "last_processed_ts": "2026-06-15T14:30:00+00:00",
+                        "kill_switch_state": "clear",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            _seed_journal(
+                vault_root,
+                "2026-06-15",
+                [
+                    _event(
+                        "engine_started",
+                        "id01",
+                        ts="2026-06-15T14:30:00+00:00",
+                    )
+                ],
+            )
+            alerts, _state, changed = ial.run_classification(
+                vault_root=vault_root,
+                state_dir=state_dir,
+                today=date(2026, 6, 15),
+                commit_state=False,
+                now=now,
+                engine_state_reader=lambda: "active",
+                market_hours_reader=lambda when: True,
+                liveness_stale_after_seconds=300,
+            )
+        self.assertTrue(changed)
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(alerts[0].tier, 1)
+        self.assertEqual(alerts[0].event_type, "engine_liveness")
+        self.assertIn("journal stale", alerts[0].message)
+
+    def test_active_engine_with_stale_journal_fires_at_exact_threshold(self):
+        now = datetime(2026, 6, 15, 14, 35, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as td:
+            vault_root = Path(td) / "vault"
+            state_dir = Path(td) / "state"
+            state_dir.mkdir()
+            (state_dir / "alert-state.json").write_text(
+                json.dumps(
+                    {
+                        "last_processed_entry_id": "id01",
+                        "last_processed_ts": "2026-06-15T14:30:00+00:00",
+                        "kill_switch_state": "clear",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            _seed_journal(
+                vault_root,
+                "2026-06-15",
+                [
+                    _event(
+                        "engine_started",
+                        "id01",
+                        ts="2026-06-15T14:30:00+00:00",
+                    )
+                ],
+            )
+            alerts, _state, changed = ial.run_classification(
+                vault_root=vault_root,
+                state_dir=state_dir,
+                today=date(2026, 6, 15),
+                commit_state=False,
+                now=now,
+                engine_state_reader=lambda: "active",
+                market_hours_reader=lambda when: True,
+                liveness_stale_after_seconds=300,
+            )
+        self.assertTrue(changed)
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(alerts[0].event_type, "engine_liveness")
+
+    def test_stale_journal_dedup_key_ignores_threshold_config_change(self):
+        now = datetime(2026, 6, 15, 14, 40, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as td:
+            vault_root = Path(td) / "vault"
+            state_dir = Path(td) / "state"
+            state_dir.mkdir()
+            (state_dir / "alert-state.json").write_text(
+                json.dumps(
+                    {
+                        "last_processed_entry_id": "id01",
+                        "last_processed_ts": "2026-06-15T14:30:00+00:00",
+                        "kill_switch_state": "clear",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            _seed_journal(
+                vault_root,
+                "2026-06-15",
+                [
+                    _event(
+                        "engine_started",
+                        "id01",
+                        ts="2026-06-15T14:30:00+00:00",
+                    )
+                ],
+            )
+            first_alerts, first_state, _changed = ial.run_classification(
+                vault_root=vault_root,
+                state_dir=state_dir,
+                today=date(2026, 6, 15),
+                commit_state=True,
+                now=now,
+                engine_state_reader=lambda: "active",
+                market_hours_reader=lambda when: True,
+                liveness_stale_after_seconds=300,
+            )
+            second_alerts, _second_state, second_changed = ial.run_classification(
+                vault_root=vault_root,
+                state_dir=state_dir,
+                today=date(2026, 6, 15),
+                commit_state=False,
+                now=now,
+                engine_state_reader=lambda: "active",
+                market_hours_reader=lambda when: True,
+                liveness_stale_after_seconds=120,
+            )
+        self.assertEqual(len(first_alerts), 1)
+        self.assertIsNotNone(first_state.alerted_liveness_key)
+        self.assertEqual(second_alerts, [])
+        self.assertFalse(second_changed)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Permanently fixes **ENGINE-DIES-AT-DAILY-CLOSEDOWN-AND-STAYS-DEAD-SILENTLY** (the 9-day outage 2026-06-02..06-11): the engine phantom-refused an adopted orphan protective stop once its 30-day adoption expired, exited clean (so `Restart=on-failure` ignored it), and stayed dead + unalerted.

## Three fixes (designed together)
- **Fix A (capital-path):** adopted-orphan-stop recognition now **self-renews** each recovery while the SAME stop protects the SAME still-held position. The 30-day clock never silently expires; the human-first adoption gate is preserved (only renewal-while-unchanged is automatic). Any drift re-refuses; a naked stop falls through to the existing `phantom_open_order` refusal. (Design A-i, not A-ii.)
- **Fix B (infra):** repo-tracked systemd `Restart=always` template bounded by `StartLimit` + an operator verify command. NOT a live VPS edit -- deploy is gated.
- **Fix C (alert):** engine-liveness check on the minute-cron Telegram path so a future death pages within minutes.

`avg_price` drift uses a `Decimal('0.01')` rounding tolerance (alongside the separate qty-drift check) so rounding noise cannot spuriously refuse.

## Tests
RED-first incl. the expired-adoption death reproduction + drift/no-position controls. Full suite: **1852 passed, 1 skipped**.

## Provenance
Built by Codex (isolated worktree); reviewed by Kimi cross-model over 2 rounds + a confirming pass. Round 1 caught + fixed **2 CRITICAL** capital-safety bugs (spurious-refuse on rounding; naked-stop handling). Dispositions in `.code-reviews/enginefix-round-{1,2}-response.md`.

## Non-blocking follow-ups (pre-merge review)
1. Make the avg_price epsilon relative if K2Bi ever trades sub-dollar tickers (currently safe -- fires only alongside qty-drift).
2. Strengthen the death-repro test to also exercise the old 30-day-lookback-only recognition refusing the expired adoption.
3. Parameterize the systemd template paper account ID at deploy time.

## Merge + deploy
Capital-path engine-recovery code. Merging to `main` does NOT touch the live engine -- the **VPS deploy is a separate gated step** (apply template, restart, verify). The current stop-adoption expires ~2026-07-11, so merge + deploy before then (stopgap: re-adopt for +30 days).

Generated with Claude Code